### PR TITLE
don't overwrite cert consumers for new capi app, testing release notes usage, !deploy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,1 @@
+- With Set-TppAttribute set to Overwrite by default, update New-TppCapiApplication to ensure our Consumers attribute update does not overwrite

--- a/VenafiTppPS/Public/New-TppCapiApplication.ps1
+++ b/VenafiTppPS/Public/New-TppCapiApplication.ps1
@@ -239,7 +239,7 @@ function New-TppCapiApplication {
             AttributeName = 'Consumers'
             Value         = $capiObject.DN
         }
-        $certUpdateResponse = Set-TppAttribute @certUpdateParams
+        $certUpdateResponse = Set-TppAttribute @certUpdateParams -NoClobber
 
         if ( $certUpdateResponse.Success ) {
             $capiObject

--- a/VenafiTppPS/VenafiTppPS.psd1
+++ b/VenafiTppPS/VenafiTppPS.psd1
@@ -104,7 +104,7 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            # ReleaseNotes = ''
+            ReleaseNotes = ''
 
         } # End of PSData hashtable
 

--- a/build/psake.ps1
+++ b/build/psake.ps1
@@ -298,7 +298,9 @@ Task Deploy -Depends BuildDocs {
             "git push origin $ENV:BHBranchName"
             cmd /c "git push origin $ENV:BHBranchName 2>&1"
             # if this is a !deploy on master, create GitHub release
+            # 20180518, stop use of this for now
             if (
+                0 -and
                 $ENV:BHBuildSystem -ne 'Unknown' -and
                 $ENV:BHBranchName -eq "master" -and
                 $ENV:BHCommitMessage -match '!deploy'


### PR DESCRIPTION
- ensure cert consumers attribute doesn't get overwritten when creating new capi app
- testing release notes in build process
- !deploy