### PR TITLE
add Get-TppPermission and refactor Get-TppObject

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
-- add status filters to Get-TppCertificateDetail, all filters added
-- certificate stage enum added
-- Get-EnumValues function added
+- add Get-TppPermission
+- refactor Get-TppObject
+    - The DN parameter is now Path which will become the standard for all functions.
+    - Classes parameter has been removed and Class been made an array
+    - Add Folder parameter to treat the Path as a folder and not an item within the parent folder.  This will retrieve all subitems.
+    - Recursive is now off by default
+- fix San-Dns name in Get-TppCertificateDetail, thanks @jeffreyluce!

--- a/VenafiTppPS/Code/Public/Get-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppObject.ps1
@@ -23,10 +23,11 @@ A list of attribute names to limit the search against.  Only valid when searchin
 The path to start our search.  If not provided, the root, \VED, is used.
 
 .PARAMETER Recursive
-Searches the subordinates of the object specified in DN.
+Searches the subordinates of the object specified in Path.
 Not supported when searching Classes or by Pattern.
 
 .PARAMETER Folder
+Treat path as root folder for search instead of the end of the path as an item wtihin the parent.
 
 .PARAMETER TppSession
 Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
@@ -47,7 +48,15 @@ PSCustomObject with the following properties:
 
 .EXAMPLE
 Get-TppObject -Recursive
-Get all objects
+Get all objects.  The default path is \VED and recursive option will search all subfolders.
+
+.EXAMPLE
+Get-TppObject -Path '\VED\Policy'
+Get the Policy item with the VED folder
+
+.EXAMPLE
+Get-TppObject -Path '\VED\Policy' -Folder
+Get items within the policy folder
 
 .EXAMPLE
 Get-TppObject -Class 'iis6'
@@ -183,7 +192,7 @@ function Get-TppObject {
         }
     }
 
-    # we have a default value even if not provided so always add path
+    # \ved is top level so need to get subitems
     if ( $Path -eq '\VED' ) {
         $byFolder = $true
     }

--- a/VenafiTppPS/Code/Public/Get-TppPermission.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppPermission.ps1
@@ -1,13 +1,21 @@
 ﻿<#
 .SYNOPSIS
-Get basic or detailed certificate information
+Get permissions for TPP objects
 
 .DESCRIPTION
-Get certificate info based on a variety of attributes.
-Additional details can be had by passing the guid.
+Determine who has rights for TPP objects and what those rights are
 
 .PARAMETER Guid
-Guid representing a unique certificate in Venafi.
+Guid representing a unique object in Venafi.
+
+.PARAMETER ExternalProviderType
+External provider type with users/groups to assign permissions.  AD and LDAP are currently supported.
+
+.PARAMETER ExternalProviderName
+Name of the external provider as configured in TPP
+
+.PARAMETER UniversalId
+The id that represents the user or group.  Use Get-TppIdentity to get the id.
 
 .PARAMETER TppSession
 Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
@@ -16,52 +24,44 @@ Session object created from New-TppSession method.  The value defaults to the sc
 Guid
 
 .OUTPUTS
-ByPath and NoPath parameter sets returns a PSCustomObject with the following properties:
-    CreatedOn
-    DN
-    Guid
-    Name
-    ParentDn
-    SchemaClass
-    _links
+List parameter set returns a PSCustomObject with the properties ObjectGuid and Permissions
 
-Guid returns a PSCustomObject with the following properties:
-    CertificateAuthorityDN
-    CertificateDetails
-    Consumers
-    Contact
-    CreatedOn
-    CustomFields
-    Description
-    DN
-    Guid
-    ManagementType
-    Name
-    ParentDn
-    ProcessingDetails
-    RenewalDetails
-    SchemaClass
-    ValidationDetails
+Local and external parameter sets returns a PSCustomObject with the following properties:
+    ObjectGuid
+    ProviderType
+    ProviderName
+    UniversalId
+    EffectivePermissions (if Effective switch is used)
+    ExplicitPermissions (if Effective switch is NOT used)
+    ImplicitPermissions (if Effective switch is NOT used)
 
 .EXAMPLE
-Get-TppCertificateDetail -ExpireBefore ([DateTime] "2018-01-01")
-Find all certificates expiring before a certain date
+Get-TppObject -Path '\VED\Policy\My folder' | Get-TppPermission
+ObjectGuid                             Permissions
+----                                   -----------
+{1234abcd-g6g6-h7h7-faaf-f50cd6610cba} {AD+mydomain.com:1234567890olikujyhtgrfedwsqa, AD+mydomain.com:azsxdcfvgbhnjmlk09877654321}
+
+Get permissions for a specific policy folder
 
 .EXAMPLE
-Get-TppCertificateDetail -ExpireBefore ([DateTime] "2018-01-01") -Limit 5
-Find 5 certificates expiring before a certain date
+Get-TppObject -Path '\VED\Policy\My folder' | Get-TppPermission -Effective
+ObjectGuid           : {1234abcd-g6g6-h7h7-faaf-f50cd6610cba}
+ProviderType         : AD
+ProviderName         : mydomain.com
+UniversalId          : 1234567890olikujyhtgrfedwsqa
+EffectivePermissions : @{IsAssociateAllowed=False; IsCreateAllowed=True; IsDeleteAllowed=True; IsManagePermissionsAllowed=True; IsPolicyWriteAllowed=True;
+                       IsPrivateKeyReadAllowed=True; IsPrivateKeyWriteAllowed=True; IsReadAllowed=True; IsRenameAllowed=True; IsRevokeAllowed=False; IsViewAllowed=True;
+                       IsWriteAllowed=True}
 
-.EXAMPLE
-Get-TppCertificateDetail -Path '\VED\Policy\My Policy'
-Find all certificates in a specific path
+ObjectGuid           : {1234abcd-g6g6-h7h7-faaf-f50cd6610cba}
+ProviderType         : AD
+ProviderName         : mydomain.com
+UniversalId          : azsxdcfvgbhnjmlk09877654321
+EffectivePermissions : @{IsAssociateAllowed=False; IsCreateAllowed=False; IsDeleteAllowed=False; IsManagePermissionsAllowed=False; IsPolicyWriteAllowed=True;
+                       IsPrivateKeyReadAllowed=False; IsPrivateKeyWriteAllowed=False; IsReadAllowed=True; IsRenameAllowed=False; IsRevokeAllowed=True; IsViewAllowed=False;
+                       IsWriteAllowed=True}
 
-.EXAMPLE
-Get-TppCertificateDetail -Path '\VED\Policy\My Policy' -Recursive
-Find all certificates in a specific path and all subfolders
-
-.EXAMPLE
-Get-TppCertificateDetail -ExpireBefore ([DateTime] "2018-01-01") -Limit 5 | Get-TppCertificateDetail
-Get detailed certificate info on the first 5 certificates expiring before a certain date
+Get effective permissions for a specific policy folder
 
 .LINK
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppPermission/
@@ -137,32 +137,47 @@ function Get-TppPermission {
                         $perms.ForEach{
                             # get details from list of perms on the object
                             # loop through and get effective perms on each by re-calling this function
-                            # TODO: update split to support local
-                            $type, $name, $id = $_.Split('+:')
-                            $effectiveParams = @{
-                                Guid                 = $thisGuid
-                                ExternalProviderType = $type
-                                ExternalProviderName = $name
-                                UniversalId          = $id
-                                Effective            = $true
+
+                            if ( $_.StartsWith('local:') ) {
+
+                                $type, $id = $_.Split(':')
+                                $effectiveParams = @{
+                                    Guid        = $thisGuid
+                                    UniversalId = $id
+                                    Effective   = $true
+                                }
+                            } else {
+                                $type, $name, $id = $_.Split('+:')
+                                $effectiveParams = @{
+                                    Guid                 = $thisGuid
+                                    ExternalProviderType = $type
+                                    ExternalProviderName = $name
+                                    UniversalId          = $id
+                                    Effective            = $true
+                                }
                             }
                             Get-TppPermission @effectiveParams
                         }
                     } else {
                         # just list out users/groups with rights
                         [PSCustomObject] @{
-                            GUID        = $thisGuid
+                            ObjectGuid  = $thisGuid
                             Permissions = $perms
                         }
                     }
                 }
 
                 {$_ -in 'Local', 'External'} {
+
                     # different URLs if local vs external
                     if ( $PSBoundParameters.ContainsKey('ExternalProviderType') ) {
                         $params.UriLeaf += "/$ExternalProviderType/$ExternalProviderName/$UniversalId"
+                        $providerType = $ExternalProviderType
+                        $providerName = $ExternalProviderName
                     } else {
                         $params.UriLeaf += "/local/$UniversalId"
+                        $providerType = 'local'
+                        $providerName = ''
                     }
 
                     if ( $PSBoundParameters.ContainsKey('Effective') ) {
@@ -171,18 +186,25 @@ function Get-TppPermission {
 
                     $response = Invoke-TppRestMethod @params
 
+                    $returnObject = [PSCustomObject] @{
+                        ObjectGuid   = $thisGuid
+                        ProviderType = $providerType
+                        ProviderName = $providerName
+                        UniversalId  = $UniversalId
+                    }
+
                     if ( $PSBoundParameters.ContainsKey('Effective') ) {
-                        [PSCustomObject] @{
-                            GUID                 = $thisGuid
+                        $returnObject | Add-Member @{
                             EffectivePermissions = $response.EffectivePermissions
                         }
                     } else {
-                        [PSCustomObject] @{
-                            GUID                = $thisGuid
+                        $returnObject | Add-Member @{
                             ExplicitPermissions = $response.ExplicitPermissions
                             ImplicitPermissions = $response.ImplicitPermissions
                         }
                     }
+
+                    $returnObject
                 }
             }
         }

--- a/VenafiTppPS/Code/Public/Get-TppPermission.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppPermission.ps1
@@ -1,0 +1,178 @@
+﻿<#
+.SYNOPSIS
+Get basic or detailed certificate information
+
+.DESCRIPTION
+Get certificate info based on a variety of attributes.
+Additional details can be had by passing the guid.
+
+.PARAMETER Guid
+Guid representing a unique certificate in Venafi.
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+Guid
+
+.OUTPUTS
+ByPath and NoPath parameter sets returns a PSCustomObject with the following properties:
+    CreatedOn
+    DN
+    Guid
+    Name
+    ParentDn
+    SchemaClass
+    _links
+
+Guid returns a PSCustomObject with the following properties:
+    CertificateAuthorityDN
+    CertificateDetails
+    Consumers
+    Contact
+    CreatedOn
+    CustomFields
+    Description
+    DN
+    Guid
+    ManagementType
+    Name
+    ParentDn
+    ProcessingDetails
+    RenewalDetails
+    SchemaClass
+    ValidationDetails
+
+.EXAMPLE
+Get-TppCertificateDetail -ExpireBefore ([DateTime] "2018-01-01")
+Find all certificates expiring before a certain date
+
+.EXAMPLE
+Get-TppCertificateDetail -ExpireBefore ([DateTime] "2018-01-01") -Limit 5
+Find 5 certificates expiring before a certain date
+
+.EXAMPLE
+Get-TppCertificateDetail -Path '\VED\Policy\My Policy'
+Find all certificates in a specific path
+
+.EXAMPLE
+Get-TppCertificateDetail -Path '\VED\Policy\My Policy' -Recursive
+Find all certificates in a specific path and all subfolders
+
+.EXAMPLE
+Get-TppCertificateDetail -ExpireBefore ([DateTime] "2018-01-01") -Limit 5 | Get-TppCertificateDetail
+Get detailed certificate info on the first 5 certificates expiring before a certain date
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCertificateDetail/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Public/Get-TppCertificateDetail.ps1
+
+.LINK
+https://docs.venafi.com/Docs/18.1SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-GET-Certificates.php?TocPath=REST%20API%20reference|Certificates%20module%20programming%20interfaces|_____3
+
+.LINK
+https://docs.venafi.com/Docs/18.1SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-GET-Certificates-guid.php?TocPath=REST%20API%20reference|Certificates%20module%20programming%20interfaces|_____5
+
+.LINK
+https://msdn.microsoft.com/en-us/library/system.web.httputility(v=vs.110).aspx
+
+#>
+function Get-TppPermission {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'Default', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Effective', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Principal', ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [String[]] $Guid,
+
+        [Parameter(Mandatory, ParameterSetName = 'Effective')]
+        [Parameter(Mandatory, ParameterSetName = 'Principal')]
+        [ValidateSet('local', 'AD', 'LDAP')]
+        [string] $ProviderType,
+
+        [Parameter(Mandatory, ParameterSetName = 'Effective')]
+        [Parameter(Mandatory, ParameterSetName = 'Principal')]
+        [string] $ProviderName,
+
+        [Parameter(Mandatory, ParameterSetName = 'Effective')]
+        [Parameter(Mandatory, ParameterSetName = 'Principal')]
+        [Alias('Universal')]
+        [string] $UniversalId,
+
+        [Parameter(ParameterSetName = 'Default')]
+        [Parameter(Mandatory, ParameterSetName = 'Effective')]
+        [switch] $Effective,
+
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate()
+
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Get'
+            UriLeaf    = 'placeholder'
+        }
+    }
+
+    process {
+
+        $GUID.ForEach{
+            $thisGuid = $_
+            $uriLeaf = "Permissions/Object/$thisGuid"
+            $params.UriLeaf = $uriLeaf
+
+            Switch ($PsCmdlet.ParameterSetName)	{
+                'Default' {
+                    $perms = Invoke-TppRestMethod @params
+                    if ( $Effective ) {
+                        $perms.ForEach{
+                            # get provider and principal
+                            $type, $name, $id = $_.Split('+:')
+                            $effectiveParams = @{
+                                Guid         = $thisGuid
+                                ProviderType = $type
+                                ProviderName = $name
+                                UniversalId  = $id
+                                Effective = $true
+                            }
+                            Get-TppPermission @effectiveParams
+                        }
+                    } else {
+                        [PSCustomObject] @{
+                            GUID        = $thisGuid
+                            Permissions = $perms
+                        }
+                    }
+                }
+
+                'Effective' {
+                    $params.UriLeaf += "/$ProviderType/$ProviderName/$UniversalId/Effective"
+                    $response = Invoke-TppRestMethod @params
+                    [PSCustomObject] @{
+                        GUID                 = $thisGuid
+                        EffectivePermissions = $response.EffectivePermissions
+                    }
+                }
+
+                'Principal' {
+                    $params.UriLeaf += "/$ProviderType/$ProviderName/$UniversalId"
+                    $response = Invoke-TppRestMethod @params
+                    [PSCustomObject] @{
+                        GUID                = $thisGuid
+                        ExplicitPermissions = $response.ExplicitPermissions
+                        ImplicitPermissions = $response.ImplicitPermissions
+                    }
+                }
+            }
+
+        }
+
+    }
+}

--- a/VenafiTppPS/Code/Public/Get-TppPermission.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppPermission.ps1
@@ -153,7 +153,11 @@ function Get-TppPermission {
                 }
 
                 'Effective' {
-                    $params.UriLeaf += "/$ProviderType/$ProviderName/$UniversalId/Effective"
+                    if ( $ProviderType -eq 'local' ) {
+                        $params.UriLeaf += "/$ProviderType/$UniversalId/Effective"
+                    } else {
+                        $params.UriLeaf += "/$ProviderType/$ProviderName/$UniversalId/Effective"
+                    }
                     $response = Invoke-TppRestMethod @params
                     [PSCustomObject] @{
                         GUID                 = $thisGuid
@@ -162,7 +166,11 @@ function Get-TppPermission {
                 }
 
                 'Principal' {
-                    $params.UriLeaf += "/$ProviderType/$ProviderName/$UniversalId"
+                    if ( $ProviderType -eq 'local' ) {
+                        $params.UriLeaf += "/$ProviderType/$UniversalId"
+                    } else {
+                        $params.UriLeaf += "/$ProviderType/$ProviderName/$UniversalId"
+                    }
                     $response = Invoke-TppRestMethod @params
                     [PSCustomObject] @{
                         GUID                = $thisGuid


### PR DESCRIPTION
- add Get-TppPermission
- refactor Get-TppObject
    - The DN parameter is now Path which will become the standard for all functions.  An alias of DN will be created.
    - Classes parameter has been removed and Class been made an array
    - Add Folder parameter to treat the Path as a folder and not an item within the parent folder.  This will retrieve all subitems.
    - Recursive is now off by default
