### PR TITLE
Fix Cannot parse input document error in Get-TppCertificate cmdlet

### DIFF
--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -96,7 +96,11 @@ function Get-TppCertificate {
             })]
         [String] $OutPath,
 
-        [Parameter()]
+        
+        [Parameter(ValueFromPipeline, ParameterSetName = 'ByObject')]
+        [Parameter(ValueFromPipeline, ParameterSetName = 'ByPath')]
+        [Parameter(ParameterSetName = 'ByObjectWithPrivateKey')]
+        [Parameter(ParameterSetName = 'ByPathWithPrivateKey')]
         [switch] $IncludeChain,
 
         [Parameter(Mandatory, ParameterSetName = 'ByObjectWithPrivateKey')]

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -96,6 +96,7 @@ function Get-TppCertificate {
             })]
         [String] $OutPath,
 
+        [Parameter()]
         [switch] $IncludeChain,
 
         [Parameter(Mandatory, ParameterSetName = 'ByObjectWithPrivateKey')]

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -166,7 +166,7 @@ function Get-TppCertificate {
 
         if ($Format -in @("Base64 (PKCS #8)", "DER", "PKCS #7")) {
             if (-not ([string]::IsNullOrEmpty($FriendlyName))) {
-                Write-Error "JKS format requires FriendlyName parameter to be set"
+                Write-Error "Only Base64, JKS, PKCS #12 formats support FriendlyName parameter"
                 Return
             }
         }

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -165,7 +165,7 @@ function Get-TppCertificate {
             Write-Error "JKS format requires FriendlyName parameter to be set"
             Return
         }
-        
+
         if (-not [string]::IsNullOrEmpty($FriendlyName)) {
             $params.Body.Add('FriendlyName', $FriendlyName)
         }

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -151,10 +151,10 @@ function Get-TppCertificate {
 
         $params.Body.CertificateDN = $Path
 
-        if ($IncludePrivateKey.IsPresent) {
+        if ($IncludePrivateKey) {
 
             # validate format to be able to export the private key
-            if ( $Format -in @("Base64", "DER", "PKCS #7") ) {
+            if ( $Format -in @("Base64 (PKCS #8)", "DER", "PKCS #7") ) {
                 Write-Error "Format '$Format' does not support private keys"
                 Return
             }
@@ -181,13 +181,15 @@ function Get-TppCertificate {
             $params.Body.Add('FriendlyName', $FriendlyName)
         }
 
-        if (($Format -in @("Base64 (PKCS #8)", "DER")) -and $IncludeChain.IsPresent)
-        {
-            Write-Error "IncludeChain is only supported when Format is Base64, JKS, PKCS #7, or PKCS #12"
-            Return
-        }
+        if ($IncludeChain) {
+            if ($Format -in @("Base64 (PKCS #8)", "DER"))
+            {
+                Write-Error "IncludeChain is only supported when Format is Base64, JKS, PKCS #7, or PKCS #12"
+                Return
+            }
 
-        $params.Body.Add('IncludeChain', $IncludeChain.IsPresent)
+            $params.Body.Add('IncludeChain', $true)
+        }
 
         $response = Invoke-TppRestMethod @params
 

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -97,8 +97,8 @@ function Get-TppCertificate {
         [String] $OutPath,
 
         
-        [Parameter(ValueFromPipeline, ParameterSetName = 'ByObject')]
-        [Parameter(ValueFromPipeline, ParameterSetName = 'ByPath')]
+        [Parameter(ParameterSetName = 'ByObject')]
+        [Parameter(ParameterSetName = 'ByPath')]
         [Parameter(ParameterSetName = 'ByObjectWithPrivateKey')]
         [Parameter(ParameterSetName = 'ByPathWithPrivateKey')]
         [switch] $IncludeChain,

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -40,8 +40,15 @@ Session object created from New-TppSession method.  The value defaults to the sc
 $certs | Get-TppCertificate -Format 'PKCS #7' -OutPath 'c:\temp'
 Get one or more certificates
 
+.EXAMPLE
+
 $certs | Get-TppCertificate -Format 'PKCS #7' -OutPath 'c:\temp' -IncludeChain
 Get one or more certificates with the certificate chain included
+
+.EXAMPLE
+
+$certs | Get-TppCertificate -Format 'PKCS #7' -OutPath 'c:\temp' -IncludeChain -FriendlyName 'MyFriendlyName'
+Get one or more certificates with the certificate chain included and friendly name attribute specified
 
 .EXAMPLE
 $certs | Get-TppCertificate -Format 'PKCS #12' -OutPath 'c:\temp' -IncludePrivateKey -SecurePassword ($password | ConvertTo-SecureString -asPlainText -Force)
@@ -50,6 +57,10 @@ Get one or more certificates with private key included
 .EXAMPLE
 $certs | Get-TppCertificate -Format 'PKCS #12' -OutPath 'c:\temp' -IncludeChain -IncludePrivateKey -SecurePassword ($password | ConvertTo-SecureString -asPlainText -Force)
 Get one or more certificates with private key and certificate chain included
+
+.EXAMPLE
+$certs | Get-TppCertificate -Format 'PKCS #12' -OutPath 'c:\temp' -IncludeChain -FriendlyName 'MyFriendlyName' -IncludePrivateKey -SecurePassword ($password | ConvertTo-SecureString -asPlainText -Force)
+Get one or more certificates with private key and certificate chain included and friendly name attribute specified
 
 .INPUTS
 InputObject or Path
@@ -99,6 +110,9 @@ function Get-TppCertificate {
         [Parameter()]
         [switch] $IncludeChain,
 
+        [Parameter()]
+        [string] $FriendlyName,
+
         [Parameter(Mandatory, ParameterSetName = 'ByObjectWithPrivateKey')]
         [Parameter(Mandatory, ParameterSetName = 'ByPathWithPrivateKey')]
         [switch] $IncludePrivateKey,
@@ -145,6 +159,15 @@ function Get-TppCertificate {
             $params.Body.Add('IncludePrivateKey', $true)
             $plainTextPassword = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword))
             $params.Body.Add('Password', $plainTextPassword)
+        }
+
+        if ($Format -ieq 'JKS' -and [string]::IsNullOrEmpty($FriendlyName)) {
+            Write-Error "JKS format requires FriendlyName parameter to be set"
+            Return
+        }
+        
+        if (-not [string]::IsNullOrEmpty($FriendlyName)) {
+            $params.Body.Add('FriendlyName', $FriendlyName)
         }
 
         if ($IncludeChain.IsPresent) {

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -96,11 +96,6 @@ function Get-TppCertificate {
             })]
         [String] $OutPath,
 
-        
-        [Parameter(ParameterSetName = 'ByObject')]
-        [Parameter(ParameterSetName = 'ByPath')]
-        [Parameter(ParameterSetName = 'ByObjectWithPrivateKey')]
-        [Parameter(ParameterSetName = 'ByPathWithPrivateKey')]
         [switch] $IncludeChain,
 
         [Parameter(Mandatory, ParameterSetName = 'ByObjectWithPrivateKey')]

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -21,6 +21,9 @@ Folder path to save the certificate to.  The name of the file will be determined
 .PARAMETER IncludeChain
 Include the certificate chain with the exported certificate.
 
+.PARAMETER FriendlyName
+The exported certificate's FriendlyName attribute. This parameter is required when Format is JKS.
+
 .PARAMETER IncludePrivateKey
 Include the private key.  The Format chosen must support private keys.
 

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -121,7 +121,7 @@ function Get-TppCertificate {
 
         $params.Body.CertificateDN = $Path
 
-        if ( $PSBoundParameters.ContainsKey('IncludePrivateKey') ) {
+        if ( $IncludePrivateKey.IsPresent) {
 
             # validate format to be able to export the private key
             if ( $Format -in @("Base64", "DER", "PKCS #7") ) {
@@ -129,7 +129,7 @@ function Get-TppCertificate {
                 Return
             }
 
-            $params.Body.Add('IncludePrivateKey', $IncludePrivateKey)
+            $params.Body.Add('IncludePrivateKey', $true)
             $plainTextPassword = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword))
             $params.Body.Add('Password', $plainTextPassword)
         }

--- a/docs/functions/Get-TppCertificate.md
+++ b/docs/functions/Get-TppCertificate.md
@@ -97,7 +97,7 @@ Accept wildcard characters: False
 ```
 
 ### -OutPath
-Folder path to save the certificate to. 
+Folder path to save the certificate to.
 The name of the file will be determined automatically.
 
 ```yaml
@@ -112,23 +112,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -IncludeChain
-Indicates whether to include certificate chain in the output file.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -IncludePrivateKey
-Include the private key. 
+Include the private key.
 The Format chosen must support private keys.
 
 ```yaml
@@ -144,7 +129,7 @@ Accept wildcard characters: False
 ```
 
 ### -SecurePassword
-Password required when including a private key. 
+Password required when including a private key.
 You must adhere to the following rules:
 - Password is at least 12 characters.
 - Comprised of at least three of the following:
@@ -166,7 +151,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml

--- a/docs/functions/Get-TppCertificate.md
+++ b/docs/functions/Get-TppCertificate.md
@@ -112,6 +112,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -IncludeChain
+Indicates whether to include certificate chain in the output file.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -IncludePrivateKey
 Include the private key. 
 The Format chosen must support private keys.


### PR DESCRIPTION
Hi Greg,
         I tried using the Get-TppCertificate cmdlet from your module to pull down a PKCS #12 certificate and kept getting a "Cannot parse input document" error. I was able to track the root cause down to the JSON object being passed to the Body parameter of Invoke-RestMethod within Invoke-TPPRestMethod. As it turns out, if you set IncludePrivateKey to the parameter $IncludePrivateKey, it will set the value to another key/value entry IsPresent with a value of true instead of just setting the value of true. I've since changed the IncludePrivateKey parameter check and tested it against our private instance of Venafi and it now works. You might also see 3 more commits on top of the fix for input document parsing error. I added this after realizing the need for an IncludeChain parameter so the exported file includes the certificate chain. Thank you in advance!