### PR TITLE
get system status, add api version checking

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,4 @@
-- Rename Get-TppIdentity to Find-TppIdentity to better reflect its purpose
-- Add parameter validation to Find-TppObject
-- Add Get-TppObject
-- Update Get-TppPermission:
-    - Add InputObject pipeline input
-    - Add Path input parameter
-    - Change permission retrieval to be effective by default
-- Update Revoke-TppCertificate
-    - Add InputObject input
-    - Add Path input
-    - Simplify output to include path and status instead of confusing response from API.
-- Fix function aliases
+- Add Get-TppSystemStatus
+- Add system version to TppSession.  Uses SystemStatus instead of SystemStatus/Version which is new to 18.3 and folks might not be running yet
+- Add framework utilizing the system version and config file to validate the current api call is supported on the current version, throw an error otherwise
+- Fix bug in Get-TppCertificate.  This was actually fixed in 0.7.2, but the release notes didn't call it out.  Thanks for the contribution, tristanbarcelon!

--- a/VenafiTppPS/Code/Classes/TppSession.ps1
+++ b/VenafiTppPS/Code/Classes/TppSession.ps1
@@ -5,6 +5,7 @@ class TppSession {
     [string] $ServerUrl
     [datetime] $ValidUntil
     [PSCustomObject] $CustomField
+    [Version] $Version
 
     TppSession () {
         # throw [System.NotImplementedException]::New()
@@ -73,6 +74,8 @@ class TppSession {
             $allFields += $deviceFields | Where-Object {$_.Guid -notin $allFields.Guid}
             $this.CustomField = $allFields
         }
+
+        $this.Version = (Get-TppSystemStatus -TppSession $this) | Select-Object -First 1 -ExpandProperty version
 
     }
 

--- a/VenafiTppPS/Code/Config/SupportedVersion.json
+++ b/VenafiTppPS/Code/Config/SupportedVersion.json
@@ -1,0 +1,6 @@
+[
+    {
+        "UriLeaf": "SystemStatus/Version",
+        "Version": "18.3"
+    }
+]

--- a/VenafiTppPS/Code/Private/Invoke-TppRestMethod.ps1
+++ b/VenafiTppPS/Code/Private/Invoke-TppRestMethod.ps1
@@ -51,6 +51,14 @@ function Invoke-TppRestMethod {
         [switch] $UseWebRequest
     )
 
+    # ensure this api is supported for the current version
+    $supportedVersion = $TppSupportedVersion.Where{$_.UriLeaf -eq $UriLeaf}
+    if ( $supportedVersion ) {
+        if ( $TppSession.Version -lt ([Version] $supportedVersion.Version) ) {
+            throw ("{0} is not a supported api call for this version (v{1}) of TPP" -f $UriLeaf, $TppSession.Version)
+        }
+    }
+
     Switch ($PsCmdlet.ParameterSetName)	{
         "Session" {
             $ServerUrl = $TppSession.ServerUrl
@@ -87,10 +95,12 @@ function Invoke-TppRestMethod {
         Write-Debug "Using Invoke-WebRequest"
         try {
             Invoke-WebRequest @params
-        } catch {
+        }
+        catch {
             $_.Exception.Response
         }
-    } else {
+    }
+    else {
         Write-Debug "Using Invoke-RestMethod"
         Invoke-RestMethod @params
     }

--- a/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+Get the TPP system status
+
+.DESCRIPTION
+Returns service module statuses for Trust Protection Platform, Log Server, and Trust Protection Platform services that run on Microsoft Internet Information Services (IIS)
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+none
+
+.OUTPUTS
+PSCustomObject
+
+.EXAMPLE
+Get-TppSystemStatus
+Get the status
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Get-TppSystemStatus/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1
+
+.LINK
+https://docs.venafi.com/Docs/17.4SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-GET-SystemStatus.php?tocpath=REST%20API%20reference%7CServiceStatus%20programming%20interfaces%7C_____1
+
+#>
+function Get-TppSystemStatus {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    $TppSession.Validate()
+
+    $params = @{
+        TppSession = $TppSession
+        Method     = 'Get'
+        UriLeaf    = 'SystemStatus'
+    }
+
+    Invoke-TppRestMethod @params
+}

--- a/VenafiTppPS/Code/VenafiTppPS.psd1
+++ b/VenafiTppPS/Code/VenafiTppPS.psd1
@@ -57,7 +57,7 @@ PowerShellVersion = '5.0'
 # RequiredAssemblies = @()
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-ScriptsToProcess = 'classes\TppSession.ps1', 'classes\TppPermission.ps1', 
+ScriptsToProcess = 'classes\TppSession.ps1', 'classes\TppPermission.ps1',
                'classes\TppObject.ps1'
 
 # Type files (.ps1xml) to be loaded when importing this module
@@ -70,22 +70,22 @@ ScriptsToProcess = 'classes\TppSession.ps1', 'classes\TppPermission.ps1',
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Find-TppCertificate', 'Find-TppIdentity', 'Find-TppObject', 
-               'Get-TppAttribute', 'Get-TppCertificate', 'Get-TppCertificateDetail', 
-               'Get-TppCustomField', 'Get-TppIdentityAttribute', 'Get-TppLog', 
-               'Get-TppObject', 'Get-TppPermission', 'Get-TppWorkflowTicket', 
-               'Move-TppObject', 'New-TppCapiApplication', 'New-TppCertificate', 
-               'New-TppObject', 'New-TppPolicy', 'New-TppSession', 
-               'Remove-TppCertificate', 'Remove-TppCertificateAssociation', 
-               'Rename-TppObject', 'Restore-TppCertificate', 'Revoke-TppCertificate', 
-               'Set-TppAttribute', 'Set-TppPermission', 
-               'Set-TppWorkflowTicketStatus', 'Test-TppIdentity', 'Test-TppObject'
+FunctionsToExport = 'Find-TppCertificate', 'Find-TppIdentity', 'Find-TppObject',
+               'Get-TppAttribute', 'Get-TppCertificate', 'Get-TppCertificateDetail',
+               'Get-TppCustomField', 'Get-TppIdentityAttribute', 'Get-TppLog',
+               'Get-TppObject', 'Get-TppPermission', 'Get-TppWorkflowTicket',
+               'Move-TppObject', 'New-TppCapiApplication', 'New-TppCertificate',
+               'New-TppObject', 'New-TppPolicy', 'New-TppSession',
+               'Remove-TppCertificate', 'Remove-TppCertificateAssociation',
+               'Rename-TppObject', 'Restore-TppCertificate', 'Revoke-TppCertificate',
+               'Set-TppAttribute', 'Set-TppPermission',
+               'Set-TppWorkflowTicketStatus', 'Test-TppIdentity', 'Test-TppObject', 'Get-TppSystemStatus'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
 
 # Variables to export from this module
-VariablesToExport = 'TppSession'
+VariablesToExport = 'TppSession', 'TppSupportedVersion'
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = 'ConvertTo-TppDN', 'Get-TppWorkflowDetail', 'Get-TppIdentity'

--- a/VenafiTppPS/Code/VenafiTppPS.psm1
+++ b/VenafiTppPS/Code/VenafiTppPS.psm1
@@ -25,6 +25,9 @@ foreach ( $folder in $folders) {
 $publicFiles = Get-ChildItem -Path $PSScriptRoot\public\*.ps1 -Recurse -ErrorAction SilentlyContinue
 Export-ModuleMember -Function $publicFiles.Basename
 
+$Script:TppSupportedVersion = ConvertFrom-Json (Get-Content "$PSScriptRoot\Config\SupportedVersion.json" -Raw)
+Export-ModuleMember -variable TppSupportedVersion
+
 $Script:TppSession = New-Object 'TppSession'
 Export-ModuleMember -variable TppSession
 


### PR DESCRIPTION
- Add Get-TppSystemStatus
- Add system version to TppSession.  Uses SystemStatus instead of SystemStatus/Version which is new to 18.3 and folks might not be running yet
- Add framework utilizing the system version and config file to validate the current api call is supported on the current version, throw an error otherwise
- Fix bug in Get-TppCertificate.  This was actually fixed in 0.7.2, but the release notes didn't call it out.  Thanks for the contribution, @tristanbarcelon !