### PR TITLE
fix validation in identity functions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,1 @@
-- v1.0!
-- Add Integrated Authentication, a credential is no longer required
-- Add Write-TppLog with support for default and custom event groups
-- Add PassThru option for all 'New-' functions, returning TppObject
-- Standardize all enums with Tpp prefix
-- Make enums/classes available outside of the module scope, access these directly at the command line.  For example, [TppObject]::new('\ved\policy\object').
-- Fix finding by Stage, StageGreaterThan, and StageLessThan in Find-TppCertificate
-- Add error handling for Get-TppSystemStatus
-- Add Get-TppVersion
-- Rename Restore-TppCertificate to Invoke-TppCertificateRenewal
-- Lots of help/documentation updates
-- Breaking change: Update New-TppObject to simplify the attributes provided, now just pass a hashtable of object key/value pairs.
-- Better parameter support for New-TppCertificate with Name and CommonName
-- Rename Get-TppLog to Read-TppLog
+- fix validation in identity functions

--- a/VenafiTppPS/Code/Public/Test-TppIdentity.ps1
+++ b/VenafiTppPS/Code/Public/Test-TppIdentity.ps1
@@ -51,9 +51,9 @@ function Test-TppIdentity {
 
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateScript( {
-                $_ -match '(AD|LDAP)+\S+:\w{32}$' -or $_ -match 'local:\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$'
+                $_ -match '^(AD|LDAP)\+.+:{?\w{32}}?$' -or $_ -match 'local:{?\w{8}-\w{4}-\w{4}-\w{4}-\w{12}}?$'
             })]
-        [Alias('PrefixedUniversal')]
+        [Alias('PrefixedUniversal', 'Contact')]
         [string[]] $PrefixedUniversalId,
 
         [Parameter()]


### PR DESCRIPTION
not sure if it's version specific, but at times the api returns identities with curly braces around the guid/id and sometimes not.  enhance the validation for Get-TppIdentityAttribute and Test-TppIdentity to accept both.