### PR TITLE
multiple fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,1 +1,4 @@
-- fix issue 89, -ProvisionCertificate not triggering a push
+- issue #92, add offset parameter to Find-TppCertificate
+- fix issue #95, allow inclusion of private key for format Base64 (PKCS #8) in Get-TppCertificate.  Earlier versions of Venafi documentation listed this incorrectly, but has been resolved.
+- fix issue #96, Get-TppCertificate failing when pipilining due to adding a key to a hashtable that already exists
+- fix issue #97, linux style paths which use / instead of \ were failing path check due to invalid regex

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,3 +2,4 @@
 - fix issue #95, allow inclusion of private key for format Base64 (PKCS #8) in Get-TppCertificate.  Earlier versions of Venafi documentation listed this incorrectly, but has been resolved.
 - fix issue #96, Get-TppCertificate failing when pipilining due to adding a key to a hashtable that already exists
 - fix issue #97, linux style paths which use / instead of \ were failing path check due to invalid regex
+- pssa fix for Read-TppLog

--- a/VenafiTppPS/Code/Private/Test-TppDnPath.ps1
+++ b/VenafiTppPS/Code/Private/Test-TppDnPath.ps1
@@ -12,10 +12,10 @@ function Test-TppDnPath {
 
     process {
         if ( $PSBoundParameters.ContainsKey('AllowRoot') ) {
-            $_ -match '(^\\VED)(\\.+)*$'
+            $_ -match '^[\\|//]VED([\\|//].+)*$'
         }
         else {
-            $_ -match '(^\\VED)(\\.+)+$'
+            $_ -match '^[\\|//]VED([\\|//].+)+$'
         }
     }
 }

--- a/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
@@ -21,6 +21,9 @@ Search recursively starting from the search path.
 Limit how many items are returned.  Default is 0 for no limit.
 It is definitely recommended to filter on another property when searching with no limit.
 
+.PARAMETER Offset
+The number of results to skip.  To achieve paging, use in conjunction with the Limit parameter.
+
 .PARAMETER Country
 Find certificates by Country attribute of Subject DN.
 
@@ -147,6 +150,10 @@ Find-TppCertificate -ExpireBefore "2018-01-01" -Limit 5
 Find 5 certificates expiring before a certain date
 
 .EXAMPLE
+Find-TppCertificate -ExpireBefore "2018-01-01" -Limit 5 -Offset 2
+Find 5 certificates expiring before a certain date
+
+.EXAMPLE
 Find-TppCertificate -Path '\VED\Policy\My Policy'
 Find all certificates in a specific path
 
@@ -223,6 +230,9 @@ function Find-TppCertificate {
 
         [Parameter()]
         [int] $Limit = 0,
+
+        [Parameter()]
+        [int] $Offset,
 
         [Parameter()]
         [Alias('C')]
@@ -364,6 +374,9 @@ function Find-TppCertificate {
         }
 
         switch ($PSBoundParameters.Keys) {
+            'Offset' {
+                $params.Body.Add( 'Offset', $Offset )
+            }
             'Country' {
                 $params.Body.Add( 'C', $Country )
             }

--- a/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
@@ -22,7 +22,7 @@ Limit how many items are returned.  Default is 0 for no limit.
 It is definitely recommended to filter on another property when searching with no limit.
 
 .PARAMETER Offset
-The number of results to skip.  To achieve paging, use in conjunction with the Limit parameter.
+The number of results to skip.
 
 .PARAMETER Country
 Find certificates by Country attribute of Subject DN.
@@ -151,7 +151,7 @@ Find 5 certificates expiring before a certain date
 
 .EXAMPLE
 Find-TppCertificate -ExpireBefore "2018-01-01" -Limit 5 -Offset 2
-Find 5 certificates expiring before a certain date
+Find 5 certificates expiring before a certain date, starting at the 3rd certificate found.
 
 .EXAMPLE
 Find-TppCertificate -Path '\VED\Policy\My Policy'

--- a/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificate.ps1
@@ -13,7 +13,7 @@ TppObject which represents a unique object
 Path to the certificate object to retrieve
 
 .PARAMETER Format
-The format of the returned certificate.
+The format of the returned certificate.  Valid formats include Base64, Base64 (PKCS #8), DER, JKS, PKCS #7, PKCS #12.
 
 .PARAMETER OutPath
 Folder path to save the certificate to.  The name of the file will be determined automatically.
@@ -44,12 +44,10 @@ $certs | Get-TppCertificate -Format 'PKCS #7' -OutPath 'c:\temp'
 Get one or more certificates
 
 .EXAMPLE
-
 $certs | Get-TppCertificate -Format 'PKCS #7' -OutPath 'c:\temp' -IncludeChain
 Get one or more certificates with the certificate chain included
 
 .EXAMPLE
-
 $certs | Get-TppCertificate -Format 'PKCS #7' -OutPath 'c:\temp' -IncludeChain -FriendlyName 'MyFriendlyName'
 Get one or more certificates with the certificate chain included and friendly name attribute specified
 
@@ -86,8 +84,7 @@ function Get-TppCertificate {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid path"
                 }
             })]
@@ -103,8 +100,7 @@ function Get-TppCertificate {
         [ValidateScript( {
                 if (Test-Path $_ -PathType Container) {
                     $true
-                }
-                else {
+                } else {
                     Throw "Output path '$_' does not exist"
                 }
             })]
@@ -137,10 +133,44 @@ function Get-TppCertificate {
             Method     = 'Post'
             UriLeaf    = 'certificates/retrieve'
             Body       = @{
-                CertificateDN = $Path
-                Format        = $Format
+                Format = $Format
             }
         }
+
+        if ($IncludePrivateKey) {
+
+            # validate format to be able to export the private key
+            if ( $Format -in @("Base64", "DER", "PKCS #7") ) {
+                throw "Format '$Format' does not support private keys"
+            }
+
+            $params.Body.IncludePrivateKey = $true
+            $plainTextPassword = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword))
+            $params.Body.Password = $plainTextPassword
+        }
+
+        if ($Format -in @("Base64 (PKCS #8)", "DER", "PKCS #7")) {
+            if (-not ([string]::IsNullOrEmpty($FriendlyName))) {
+                throw "Only Base64, JKS, PKCS #12 formats support FriendlyName parameter"
+            }
+        } else {
+            if ($Format -ieq 'JKS' -and [string]::IsNullOrEmpty($FriendlyName)) {
+                throw "JKS format requires FriendlyName parameter to be set"
+            }
+        }
+
+        if (-not [string]::IsNullOrEmpty($FriendlyName)) {
+            $params.Body.FriendlyName = $FriendlyName
+        }
+
+        if ($IncludeChain) {
+            if ( $Format -in @("Base64 (PKCS #8)", "DER") ) {
+                throw "IncludeChain is only supported when Format is Base64, JKS, PKCS #7, or PKCS #12"
+            }
+
+            $params.Body.IncludeChain = $true
+        }
+
     }
 
     process {
@@ -151,57 +181,16 @@ function Get-TppCertificate {
 
         $params.Body.CertificateDN = $Path
 
-        if ($IncludePrivateKey) {
-
-            # validate format to be able to export the private key
-            if ( $Format -in @("Base64 (PKCS #8)", "DER", "PKCS #7") ) {
-                Write-Error "Format '$Format' does not support private keys"
-                Return
-            }
-
-            $params.Body.Add('IncludePrivateKey', $true)
-            $plainTextPassword = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword))
-            $params.Body.Add('Password', $plainTextPassword)
-        }
-
-        if ($Format -in @("Base64 (PKCS #8)", "DER", "PKCS #7")) {
-            if (-not ([string]::IsNullOrEmpty($FriendlyName))) {
-                Write-Error "Only Base64, JKS, PKCS #12 formats support FriendlyName parameter"
-                Return
-            }
-        }
-        else {
-            if ($Format -ieq 'JKS' -and [string]::IsNullOrEmpty($FriendlyName)) {
-                Write-Error "JKS format requires FriendlyName parameter to be set"
-                Return
-            }
-        }
-
-        if (-not [string]::IsNullOrEmpty($FriendlyName)) {
-            $params.Body.Add('FriendlyName', $FriendlyName)
-        }
-
-        if ($IncludeChain) {
-            if ($Format -in @("Base64 (PKCS #8)", "DER"))
-            {
-                Write-Error "IncludeChain is only supported when Format is Base64, JKS, PKCS #7, or PKCS #12"
-                Return
-            }
-
-            $params.Body.Add('IncludeChain', $true)
-        }
-
         $response = Invoke-TppRestMethod @params
 
         if ( $PSBoundParameters.ContainsKey('OutPath') ) {
             if ( $response.PSobject.Properties.name -contains "CertificateData" ) {
-                $outFile = join-path $OutPath ($response.FileName)
+                $outFile = Join-Path $OutPath ($response.FileName)
                 $bytes = [Convert]::FromBase64String($response.CertificateData)
                 [IO.File]::WriteAllBytes($outFile, $bytes)
-                write-verbose ('Saved {0} of format {1}' -f $outFile, $response.Format)
+                Write-Verbose ('Saved {0} of format {1}' -f $outFile, $response.Format)
             }
-        }
-        else {
+        } else {
             $response
         }
     }

--- a/VenafiTppPS/Code/Public/New-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/New-TppObject.ps1
@@ -102,8 +102,8 @@ function New-TppObject {
     }
 
     # ensure the parent folder exists
-    if ( -not (Test-TppObject -Path (Split-Path $Path -Parent) -ExistOnly -TppSession $TppSession) ) {
-        throw ("The parent folder, {0}, of your new object does not exist" -f (Split-Path $Path -Parent))
+    if ( -not (Test-TppObject -Path (Split-Path -Path $Path -Parent) -ExistOnly -TppSession $TppSession) ) {
+        throw ("The parent folder, {0}, of your new object does not exist" -f (Split-Path -Path $Path -Parent))
     }
 
     if ( $PSBoundParameters.ContainsKey('ProvisionCertificate') -and (-not $Attribute.Certificate) ) {

--- a/VenafiTppPS/Code/Public/Read-TppLog.ps1
+++ b/VenafiTppPS/Code/Public/Read-TppLog.ps1
@@ -87,8 +87,7 @@ function Read-TppLog {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                }
-                else {
+                } else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -125,57 +124,65 @@ function Read-TppLog {
         [TppSession] $TppSession = $Script:TppSession
     )
 
-    $TppSession.Validate()
+    begin {
 
-    $params = @{
-        TppSession = $TppSession
-        Method     = 'Get'
-        UriLeaf    = 'Log'
-        Body       = @{ }
-    }
+        $TppSession.Validate()
 
-    switch ($PSBoundParameters.Keys) {
-        'InputObject' {
-            $params.Body.Add('Component', $InputObject.Path)
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Get'
+            UriLeaf    = 'Log'
+            Body       = @{ }
         }
 
-        'Path' {
-            $params.Body.Add('Component', $Path)
-        }
+        switch ($PSBoundParameters.Keys) {
 
-        'Severity' {
-            $params.Body.Add('Severity', $Severity)
-        }
+            'Severity' {
+                $params.Body.Add('Severity', $Severity)
+            }
 
-        'StartTime' {
-            $params.Body.Add('FromTime', ($StartTime | ConvertTo-UtcIso8601) )
-        }
+            'StartTime' {
+                $params.Body.Add('FromTime', ($StartTime | ConvertTo-UtcIso8601) )
+            }
 
-        'EndTime' {
-            $params.Body.Add('ToTime', ($EndTime | ConvertTo-UtcIso8601) )
-        }
+            'EndTime' {
+                $params.Body.Add('ToTime', ($EndTime | ConvertTo-UtcIso8601) )
+            }
 
-        'Text1' {
-            $params.Body.Add('Text1', $Text1)
-        }
+            'Text1' {
+                $params.Body.Add('Text1', $Text1)
+            }
 
-        'Text2' {
-            $params.Body.Add('Text2', $Text2)
-        }
+            'Text2' {
+                $params.Body.Add('Text2', $Text2)
+            }
 
-        'Value1' {
-            $params.Body.Add('Value1', $Value1)
-        }
+            'Value1' {
+                $params.Body.Add('Value1', $Value1)
+            }
 
-        'Value2' {
-            $params.Body.Add('Value2', $Value2)
-        }
+            'Value2' {
+                $params.Body.Add('Value2', $Value2)
+            }
 
-        'Limit' {
-            $params.Body.Add('Limit', $Limit)
+            'Limit' {
+                $params.Body.Add('Limit', $Limit)
+            }
         }
     }
 
-    Invoke-TppRestMethod @params | Select-Object -ExpandProperty LogEvents
+    process {
 
+        switch ($PSBoundParameters.Keys) {
+            'InputObject' {
+                $params.Body.Component = $InputObject.Path
+            }
+
+            'Path' {
+                $params.Body.Component = $Path
+            }
+        }
+
+        Invoke-TppRestMethod @params | Select-Object -ExpandProperty LogEvents
+    }
 }


### PR DESCRIPTION
- issue #92, add offset parameter to Find-TppCertificate
- fix issue #95, allow inclusion of private key for format Base64 (PKCS #8) in Get-TppCertificate.  Earlier versions of Venafi documentation listed this incorrectly, but has been resolved.
- fix issue #96, Get-TppCertificate failing when pipilining due to adding a key to a hashtable that already exists
- fix issue #97, linux style paths which use / instead of \ were failing path check due to invalid regex