### PR TITLE
remove unnecessary checks conflcting with linux

### DIFF
--- a/VenafiTppPS/Code/Public/New-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/New-TppObject.ps1
@@ -19,6 +19,7 @@ These will be specific to the object class being created.
 .PARAMETER ProvisionCertificate
 If creating an application object, you can optionally push the certificate once the creation is complete.
 Only available if a 'Certificate' key containing the certificate path is provided for Attribute.
+Please note, this feature was added in v18.3.
 
 .PARAMETER PassThru
 Return a TppObject representing the newly created object.
@@ -94,17 +95,17 @@ function New-TppObject {
         [TppSession] $TppSession = $Script:TppSession
     )
 
-    # $TppSession.Validate()
+    $TppSession.Validate()
 
     # ensure the object doesn't already exist
-    if ( Test-TppObject -Path $Path -ExistOnly -TppSession $TppSession ) {
-        throw ("New object to be created, {0}, already exists" -f $Path)
-    }
+    # if ( Test-TppObject -Path $Path -ExistOnly -TppSession $TppSession ) {
+    #     throw ("New object to be created, {0}, already exists" -f $Path)
+    # }
 
     # ensure the parent folder exists
-    if ( -not (Test-TppObject -Path (Split-Path -Path $Path -Parent) -ExistOnly -TppSession $TppSession) ) {
-        throw ("The parent folder, {0}, of your new object does not exist" -f (Split-Path -Path $Path -Parent))
-    }
+    # if ( -not (Test-TppObject -Path (Split-Path -Path $Path -Parent) -ExistOnly -TppSession $TppSession) ) {
+    #     throw ("The parent folder, {0}, of your new object does not exist" -f (Split-Path -Path $Path -Parent))
+    # }
 
     if ( $PSBoundParameters.ContainsKey('ProvisionCertificate') -and (-not $Attribute.Certificate) ) {
         Write-Warning 'A ''Certificate'' key containing the certificate path must be provided for Attribute when using ProvisionCertificate, eg. -Attribute @{''Certificate''=''\Ved\Policy\mycert.com''}.  Certificate provisioning will not take place.'

--- a/build/Set-ModuleMetadata.ps1
+++ b/build/Set-ModuleMetadata.ps1
@@ -52,11 +52,11 @@ try {
     Try importing the PSD manually in a local powershell session to verify the cause of this error (import-powershelldatafile <psd1 file>) $_"
 }
 
-# [version]$version = $Manifest.ModuleVersion
-# Write-Output "Old Version - $Version"
-# # Add one to the build of the version number
-# [version]$NewVersion = "{0}.{1}.{2}" -f $Version.Major, $Version.Minor, ($Version.Build + 1)
-$newVersion = [version] $env:BUILD_BUILDNUMBER
+[version]$version = $Manifest.ModuleVersion
+Write-Output "Old Version - $Version"
+# Add one to the build of the version number
+[version]$NewVersion = "{0}.{1}.{2}" -f $Version.Major, $Version.Minor, ($Version.Build + 1)
+# $newVersion = [version] $env:BUILD_BUILDNUMBER
 Write-Output "New Version - $NewVersion"
 
 

--- a/build/Set-ModuleMetadata.ps1
+++ b/build/Set-ModuleMetadata.ps1
@@ -52,11 +52,13 @@ try {
     Try importing the PSD manually in a local powershell session to verify the cause of this error (import-powershelldatafile <psd1 file>) $_"
 }
 
-[version]$version = $Manifest.ModuleVersion
-Write-Output "Old Version - $Version"
-# Add one to the build of the version number
-[version]$NewVersion = "{0}.{1}.{2}" -f $Version.Major, $Version.Minor, ($Version.Build + 1)
+# [version]$version = $Manifest.ModuleVersion
+# Write-Output "Old Version - $Version"
+# # Add one to the build of the version number
+# [version]$NewVersion = "{0}.{1}.{2}" -f $Version.Major, $Version.Minor, ($Version.Build + 1)
+$newVersion = [version] $env:BUILD_BUILDNUMBER
 Write-Output "New Version - $NewVersion"
+
 
 # Load the module, read the exported functions and aliases, update the psd1
 $FunctionFiles = Get-ChildItem ".\$ModuleName\code\Public\*.ps1" |


### PR DESCRIPTION
there were some checks to ensure our new object creation would be successful, but are causing issues on linux.  these checks aren't needed as the api itself will fail so these have been removed.