### PR TITLE
Separate getting and managing tokens from using them

### DIFF
--- a/VenafiTppPS/Code/Classes/TppSession.ps1
+++ b/VenafiTppPS/Code/Classes/TppSession.ps1
@@ -7,7 +7,7 @@ class TppSession {
     [PSCustomObject] $Key
     [PSCustomObject] $Token
     [PSCustomObject] $CustomField
-    # [Version] $Version
+    [Version] $Version
 
     TppSession () {
         # throw [System.NotImplementedException]::New()
@@ -85,6 +85,11 @@ class TppSession {
         # TODO: can't assume scope covers the below, need to update functions which rely on this
         #   BeardedPrincess: The Metadata/GetItemsForClass function does not require any special scope, just a valid token _should_ work
         $this.GetTppCustomFieldOnConnect()
+        
+        # token-based auth was introduced in 19.2, and GET /systemstatus/version introduced in 18.3. So, if we're doing token auth, we can
+        #  get the version upon connecting!
+        #  FYI - The docs say that users need "Read" access to the engine root for /systemstatus/version - this is a doc bug and has been reported
+        $this.Version = Get-TppVersion -TppSession $this
     }
 
     # connect for key based
@@ -119,8 +124,8 @@ class TppSession {
             Credential = $Credential
         }
 
-        # $this.GetTppCustomFieldOnConnect()
-        # $this.Version = (Get-TppSystemStatus -TppSession $this) | Select-Object -First 1 -ExpandProperty version
+        $this.GetTppCustomFieldOnConnect()
+        # $this.Version = Get-TppVersion -TppSession $this
 
     }
 

--- a/VenafiTppPS/Code/Private/Invoke-TppRestMethod.ps1
+++ b/VenafiTppPS/Code/Private/Invoke-TppRestMethod.ps1
@@ -101,7 +101,7 @@ function Invoke-TppRestMethod {
         $params.Body = $restBody
     } else {
         # if there is no querystring, we need to append a trailing slash to avoid a HTTP 307/401
-        if ( $Method -eq 'Get' -and (-not $uri.EndsWith('/')) ) {
+        if ( $Method -eq 'Get' -and (-not $uri.EndsWith('/')) -and (-not $uri.ToLower().EndsWith('systemstatus/version')) ) {
             $params.Uri += '/'
         }
     }
@@ -124,7 +124,7 @@ function Invoke-TppRestMethod {
         try {
             Invoke-RestMethod @params
         } catch {
-            throw ('"{0} {1}: {2}' -f $_.Exception.Response.StatusCode.value__, $_.Exception.Response.StatusDescription, $_ | Out-String )
+            throw ('{0} {1}: {2}' -f $_.Exception.Response.StatusCode.value__, $_.Exception.Response.StatusDescription, $_ | Out-String )
         }
     }
 }

--- a/VenafiTppPS/Code/Public/Grant-TppToken.ps1
+++ b/VenafiTppPS/Code/Public/Grant-TppToken.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+Get an API Access and Refresh Token from TPP for use in New-TPPSession (or other scripts/utilities that take such a token)
+
+.DESCRIPTION
+Accepts username/password credential, scope, and ClientId to get a token grant from specified TPP server.
+
+.PARAMETER ServerUrl
+URL for the Venafi server.
+
+.PARAMETER Credential
+Username / password credential used to request API Token
+
+.PARAMETER ClientId
+Applcation Id configured in Venafi for token-based authentication
+
+.PARAMETER Scope
+Hashtable with Scopes and privilege restrictions.
+The key is the scope and the value is one or more privilege restrictions separated by commas.
+
+.EXAMPLE
+Grant-TPPToken -ServerUrl 'https://mytppserver.example.com' -Scope @{ Certificate = "manage,discover"; Config = "manage" } -ClientId 'MyAppId' -Credential $credential
+
+#>
+function Grant-TppToken {
+
+    [CmdletBinding()]
+
+    param (
+        [Parameter(Mandatory)]
+        [string] $ServerUrl,
+        
+        [Parameter(Mandatory)]
+        [string] $ClientId,
+        
+        [Parameter(Mandatory)]
+        [hashtable] $Scope = @{'any' = $null },
+        
+        [Parameter(Mandatory, ParameterSetName = 'OAuth')]
+        [System.Management.Automation.PSCredential] $Credential,
+        
+        [Parameter(ParameterSetName = 'OAuth')]
+        [string] $State
+        
+        #[Parameter(Mandatory, ParameterSetName = 'Certificate')]
+        #[System.Management.Automation.PSCredential] $Credential,
+    )
+
+    $ServerUrl = $ServerUrl.Trim('/')
+    # The authorize endpoints for token auth are not under /vedsdk, remove it if it was added by mistake
+    $ServerUrl = $ServerUrl.Trim('/vedsdk')
+    # add prefix if just server url was provided
+    if ( $ServerUrl -notlike 'https://*') {
+        $ServerUrl = 'https://{0}' -f $ServerUrl
+    }
+    
+    $scopeString = @(
+                    $scope.GetEnumerator() | ForEach-Object {
+                        if ($_.Value) {
+                            '{0}:{1}' -f $_.Key, $_.Value
+                        } else {
+                            $_.Key
+                        }
+                    }
+                ) -join ';'
+
+    $params = @{
+        Method    = 'Post'
+        ServerUrl = $ServerUrl
+        UriRoot   = 'vedauth'
+        Body      = @{
+            client_id = $ClientId
+            scope = $scopeString
+        }
+    }
+
+    if ( $Credential ) {
+        $params.UriLeaf = 'authorize/oauth'
+        $params.Body.username = $Credential.UserName
+        $params.Body.password = $Credential.GetNetworkCredential().Password
+    } else {
+        $params.UriLeaf = 'authorize/integrated'
+        $params.UseDefaultCredentials = $true
+    }
+
+    if ( $State ) {
+        $params.Body.state = $State
+    }
+
+    $response = Invoke-TppRestMethod @params
+
+    Write-Verbose ($response | Out-String)
+
+    $Token = [PSCustomObject]@{
+        AccessToken  = $response.access_token
+        RefreshToken = $response.refresh_token
+        Scope        = $response.scope
+        Identity     = $response.identity
+        TokenType    = $response.token_type
+        ClientId     = $ClientId
+        Expires = ([datetime] '1970-01-01 00:00:00').AddSeconds($response.Expires)
+    }
+
+    return $Token
+}
+
+<#
+## Refresh Token
+
+ Write-Verbose ("RefreshUntil: {0}, Current: {1}" -f $this.Token.RefreshUntil, (Get-Date).ToUniversalTime())
+                if ( $this.Token.RefreshUntil -and $this.Token.RefreshUntil -lt (Get-Date) ) {
+                    throw "The refresh token has expired.  You must create a new session with New-TppSession."
+                }
+
+                if ( $this.Token.RefreshToken ) {
+
+                    $params = @{
+                        Method    = 'Post'
+                        ServerUrl = $this.ServerUrl
+                        UriRoot   = 'vedauth'
+                        UriLeaf   = 'authorize/token'
+                        Body      = @{
+                            refresh_token = $this.Token.RefreshToken
+                            client_id     = $this.Token.ClientId
+                        }
+                    }
+                    $response = Invoke-TppRestMethod @params
+
+                    Write-Verbose ($response | Out-String)
+
+                    $this.Expires = ([datetime] '1970-01-01 00:00:00').AddSeconds($response.expires)
+                    $this.Token = [PSCustomObject]@{
+                        AccessToken  = $response.access_token
+                        RefreshToken = $response.refresh_token
+                        Scope        = $response.scope
+                        Identity     = $this.Token.Identity
+                        ClientId     = $this.Token.ClientId
+                        TokenType    = $response.token_type
+                        RefreshUntil = ([datetime] '1970-01-01 00:00:00').AddSeconds($response.refresh_until)
+                    }
+
+                } else {
+                    throw "The token has expired and no refresh token exists.  You must create a new session with New-TppSession."
+                }
+#>

--- a/VenafiTppPS/Code/VenafiTppPS.psd1
+++ b/VenafiTppPS/Code/VenafiTppPS.psd1
@@ -81,7 +81,7 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'ConvertTo-TppGuid',
                'Remove-TppCertificate', 'Remove-TppCertificateAssociation', 
                'Rename-TppObject', 'Revoke-TppCertificate', 'Set-TppAttribute', 
                'Set-TppPermission', 'Set-TppWorkflowTicketStatus', 
-               'Test-TppIdentity', 'Test-TppObject', 'Write-TppLog'
+               'Test-TppIdentity', 'Test-TppObject', 'Write-TppLog', 'Grant-TppToken'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
#94 

Having an access token (and a server URL) should be all you need to run a script using token-based authentication. How you got the access token should not matter (eventually, people will get their access tokens through the UI in Aperture - as well as being able to get them via API). 

This is why authentication (/vedauth) was pulled completely out of the /vedsdk site, and now runs in its own app pool. Architecturally, folks may only deploy /vedauth to one internal server, but allow /vedsdk to be accessible over the internet.

In addition to supporting this methodology, this module should help people be able to get and maintain those access tokens easily. I've started with Grant-TppToken (which would eventually accept a refresh_token, as well as supporting integrated - which probably can do already, and certificate auth). In addition, we will need to implement a Revoke-TppToken so tokens can be removed if not needed.  

Take a look, there's still a lot to do here, but I wanted to be able to show at least what I was thinking.