### PR TITLE
add missing 'created' filters to Find-TppCertificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.0.5
+- Add missing filters CreateDate, CreatedBefore, and CreatedAfter to Find-TppCertificate, [#117](https://github.com/gdbarron/VenafiTppPS/issues/117).  Thanks @doyle043!
+
 ## v2.0.4
 - Fix header getting stripped causing Write-TppLog to fail, #114
 - Update Invoke-TppRestMethod to retry with trailing slash for all methods, not just Get

--- a/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
@@ -321,6 +321,7 @@ function Find-TppCertificate {
         [bool] $NetworkValidationEnabled,
 
         [Parameter()]
+        [Alias('CreatedOn')]
         [datetime] $CreateDate,
 
         [Parameter()]
@@ -372,6 +373,15 @@ function Find-TppCertificate {
         }
 
         switch ($PSBoundParameters.Keys) {
+            'CreateDate' {
+                $params.Body.Add( 'CreatedOn', ($CreatedDate | ConvertTo-UtcIso8601) )
+            }
+            'CreatedBefore' {
+                $params.Body.Add( 'CreatedOnLess', ($CreatedBefore | ConvertTo-UtcIso8601) )
+            }
+            'CreatedAfter' {
+                $params.Body.Add( 'CreatedOnGreater', ($CreatedAfter | ConvertTo-UtcIso8601) )
+            }
             'Offset' {
                 $params.Body.Add( 'Offset', $Offset )
             }

--- a/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
@@ -322,7 +322,7 @@ function Find-TppCertificate {
 
         [Parameter()]
         [Alias('CreatedOn')]
-        [datetime] $CreateDate,
+        [datetime] $CreatedDate,
 
         [Parameter()]
         [Alias('CreatedOnGreater')]
@@ -373,7 +373,7 @@ function Find-TppCertificate {
         }
 
         switch ($PSBoundParameters.Keys) {
-            'CreateDate' {
+            'CreatedDate' {
                 $params.Body.Add( 'CreatedOn', ($CreatedDate | ConvertTo-UtcIso8601) )
             }
             'CreatedBefore' {

--- a/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
@@ -102,7 +102,7 @@ Only include certificates in an error state
 .PARAMETER NetworkValidationEnabled
 Only include certificates with network validation enabled or disabled
 
-.PARAMETER CreateDate
+.PARAMETER CreatedDate
 Find certificates that were created at an exact date and time
 
 .PARAMETER CreatedAfter


### PR DESCRIPTION
Add missing filters CreatedDate, CreatedBefore, and CreatedAfter to Find-TppCertificate.  Renamed CreateDate to CreatedDate to match others.