### PR TITLE
Hide verbose logging secrets, init codesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,32 @@
+## v2.1.0
+- Update Get-TppCertificateDetail help to ensure output lists the correct properties, [#119](https://github.com/gdbarron/VenafiTppPS/issues/119).  Thanks @doyle043!
+- Hide secret info, eg. passwords, tokens, etc, when verbose logging.  [#120](https://github.com/gdbarron/VenafiTppPS/issues/120).  Thanks @bwright86!
+- Add search, get, and remove code sign project and environment functions
+- Fix, provide the correct error message when making rest call and testing to see if a trailing slash is needed or not
+- Update New-TppSession to ensure $TppSession is created even if subsequent custom field calls fail
+- Update TppSession object Validate method to check if token auth is required.  Needed for code sign.
+
 ## v2.0.5
 - Add missing filters CreateDate, CreatedBefore, and CreatedAfter to Find-TppCertificate, [#117](https://github.com/gdbarron/VenafiTppPS/issues/117).  Thanks @doyle043!
 
 ## v2.0.4
-- Fix header getting stripped causing Write-TppLog to fail, #114
+- Fix header getting stripped causing Write-TppLog to fail, [#114](https://github.com/gdbarron/VenafiTppPS/issues/114).  Thanks @stevekeever!
 - Update Invoke-TppRestMethod to retry with trailing slash for all methods, not just Get
 
 ## v2.0.3
 - Add Origin property when creating a new certificate
-- Add icon to project, #37
+- Add icon to project, [#37](https://github.com/gdbarron/VenafiTppPS/issues/37)
 
 ## v2.0.2
-- Process to convert a secure password to plain text was failing on Linux, #108
+- Process to convert a secure password to plain text was failing on Linux, [#108](https://github.com/gdbarron/VenafiTppPS/issues/108).  Thanks @macflurry7!
 
 ## v2.0.1
-- Add Import-TppCertificate, #88
-- Make Invoke-TppRestMethod accessible, #106
+- Add Import-TppCertificate, [#88](https://github.com/gdbarron/VenafiTppPS/issues/88).  Thanks @smokey7722!
+- Make Invoke-TppRestMethod accessible, [#106](https://github.com/gdbarron/VenafiTppPS/issues/106).  Thanks @wilddev65!
 - Fix verbose being turned on incorrectly in New-TppSession when getting by token
 
 ## v2.0.0
-- Add token-based authentication support, Integrated, OAuth, and Certificate. Tokens can be used in or out of this module. #94
+- Add token-based authentication support, Integrated, OAuth, and Certificate. Tokens can be used in or out of this module. [#94](https://github.com/gdbarron/VenafiTppPS/issues/94).  Thanks @BeardedPrincess!
 - Add CertificateType option to New-TppCertificate
 - Add support for GET api calls which require a trailing slash
 - Fixes in multiple functions where .Add on a hashtable was called in the process block

--- a/VenafiTppPS/Code/Classes/TppSession.ps1
+++ b/VenafiTppPS/Code/Classes/TppSession.ps1
@@ -15,9 +15,20 @@ class TppSession {
     }
 
     [void] Validate() {
+        $this.Validate($false)
+    }
+
+    [void] Validate(
+        [bool] $TokenOnly
+    ) {
 
         if ( -not $this.Key -and -not $this.Token ) {
             throw "You must first connect to the TPP server with New-TppSession"
+        }
+
+        # newer api calls may only accept token based auth
+        if ( $TokenOnly -and -not $this.Token ) {
+            throw "This function requires the use of token-based authentication"
         }
 
         # if we know the session is still valid, don't bother checking with the server
@@ -51,11 +62,11 @@ class TppSession {
                     }
                 }
             } else {
-               # token
-               # By default, access tokens are long-lived (90 day default). Refreshing the token should be handled outside of this class, so that the
-               #  refresh token and access token can be properly maintained and passed to the script.
+                # token
+                # By default, access tokens are long-lived (90 day default). Refreshing the token should be handled outside of this class, so that the
+                #  refresh token and access token can be properly maintained and passed to the script.
 
-               # We have to assume a good token here and ensure Invoke-TPPRestMethod catches and handles the condition where a token expires
+                # We have to assume a good token here and ensure Invoke-TPPRestMethod catches and handles the condition where a token expires
             }
         }
     }

--- a/VenafiTppPS/Code/Enum/TppCodeSignProjectStatus.ps1
+++ b/VenafiTppPS/Code/Enum/TppCodeSignProjectStatus.ps1
@@ -1,4 +1,4 @@
-enum TppCodeSignStatus {
+enum TppCodeSignProjectStatus {
     Disabled = 0
     Enabled = 1
     Draft = 2

--- a/VenafiTppPS/Code/Enum/TppCodeSignResult.ps1
+++ b/VenafiTppPS/Code/Enum/TppCodeSignResult.ps1
@@ -1,0 +1,27 @@
+enum TppCodeSignResult {
+    None	=	0
+    Success	=	1
+    InsufficientPermission	=	2
+    CreateFailure	=	3
+    UpdateFailure	=	4
+    DeleteFailure	=	5
+    RenameFailure	=	6
+    ObjectNotFound	=	7
+    IncorrectObjectType	=	8
+    ObjectHasChildren	=	9
+    AssignPermissionFailure	=	10
+    RelatedObjectNotSaved	=	11
+    RemoteError	=	12
+    AssignProjectPermissionFailure	=	1000
+    DuplicateUserAssignment	=	1001
+    UserNotFound	=	1002
+    ObjectInGroup	=	2000
+    ObjectNotInGroup	=	2001
+    ObjectAlreadyExists	=	2002
+    EnvironmentMoveRestricted	=	3000
+    ValueProhibitedByTemplate	=	3001
+    KeyAccessFailure	=	3002
+    QueryFailure	=	3003
+    ImportFailure	=	3004
+    ObjectsPending	=	3005
+}

--- a/VenafiTppPS/Code/Enum/TppCodeSignStatus.ps1
+++ b/VenafiTppPS/Code/Enum/TppCodeSignStatus.ps1
@@ -1,0 +1,6 @@
+enum TppCodeSignStatus {
+    Disabled = 0
+    Enabled = 1
+    Draft = 2
+    Pending = 3
+}

--- a/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignEnvironment.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+Convert datetime to UTC ISO 8601 format
+
+.DESCRIPTION
+Convert datetime to UTC ISO 8601 format
+
+.PARAMETER InputObject
+DateTime object
+
+.INPUTS
+InputObject
+
+.OUTPUTS
+System.String
+
+.EXAMPLE
+(get-date) | ConvertTo-UtcIso8601
+
+#>
+function ConvertTo-TppCodeSignEnvironment {
+
+    [CmdletBinding()]
+
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
+        [PSCustomObject] $InputObject
+    )
+
+    begin {
+    }
+
+    process {
+        $InputObject | Select-Object -ExcludeProperty Dn, Type, OrganizationalUnit, IpAddressRestriction, KeyUseFlowDN, TemplateDN, CertificateAuthorityDN, CertificateDN, CertificateSubject, City, KeyAlgorithm, KeyStorageLocation, Organization, OrganizationUnit, SANEmail, State, Country -Property *,
+        @{
+            n = 'Path'
+            e = {
+                $_.Dn
+            }
+        },
+        @{
+            n = 'Name'
+            e = { Split-Path $_.DN -Leaf }
+        },
+        @{
+            n = 'TypeName'
+            e = { $_.Type }
+        },
+        @{
+            n = 'OrganizationalUnit'
+            e = { $_.OrganizationalUnit.Value }
+        },
+        @{
+            n = 'IPAddressRestriction'
+            e = { $_.IPAddressRestriction.Items }
+        },
+        @{
+            n = 'KeyUseFlowPath'
+            e = { $_.KeyUseFlowDN }
+        },
+        @{
+            n = 'TemplatePath'
+            e = { $_.TemplateDN }
+        },
+        @{
+            n = 'CertificateAuthorityPath'
+            e = { $_.CertificateAuthorityDN.Value }
+        },
+        @{
+            n = 'CertificatePath'
+            e = { $_.CertificateDN }
+        },
+        @{
+            n = 'CertificateSubject'
+            e = { $_.CertificateSubject.Value }
+        },
+        @{
+            n = 'City'
+            e = { $_.City.Value }
+        },
+        @{
+            n = 'KeyAlgorithm'
+            e = { $_.KeyAlgorithm.Value }
+        },
+        @{
+            n = 'KeyStorageLocation'
+            e = { $_.KeyStorageLocation.Value }
+        },
+        @{
+            n = 'Organization'
+            e = { $_.Organization.Value }
+        },
+        @{
+            n = 'OrganizationUnit'
+            e = { $_.OrganizationUnit.Value }
+        },
+        @{
+            n = 'SANEmail'
+            e = { $_.SANEmail.Value }
+        },
+        @{
+            n = 'State'
+            e = { $_.State.Value }
+        },
+        @{
+            n = 'Country'
+            e = { $_.Country.Value }
+        }
+
+    }
+}

--- a/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignEnvironment.ps1
@@ -1,21 +1,21 @@
 <#
 .SYNOPSIS
-Convert datetime to UTC ISO 8601 format
+Convert code sign certificate environment to something powershell friendly
 
 .DESCRIPTION
-Convert datetime to UTC ISO 8601 format
+Convert code sign certificate environment to something powershell friendly
 
 .PARAMETER InputObject
-DateTime object
+Code sign certificate environment object
 
 .INPUTS
 InputObject
 
 .OUTPUTS
-System.String
+PSCustomObject
 
 .EXAMPLE
-(get-date) | ConvertTo-UtcIso8601
+$envObj | ConvertTo-TppCodeSignEnvironment
 
 #>
 function ConvertTo-TppCodeSignEnvironment {

--- a/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignEnvironment.ps1
@@ -32,7 +32,11 @@ function ConvertTo-TppCodeSignEnvironment {
     }
 
     process {
-        $InputObject | Select-Object -ExcludeProperty Dn, Type, OrganizationalUnit, IpAddressRestriction, KeyUseFlowDN, TemplateDN, CertificateAuthorityDN, CertificateDN, CertificateSubject, City, KeyAlgorithm, KeyStorageLocation, Organization, OrganizationUnit, SANEmail, State, Country -Property *,
+        $InputObject | Select-Object  -Property `
+        @{
+            n = 'Name'
+            e = { Split-Path $_.DN -Leaf }
+        },
         @{
             n = 'Path'
             e = {
@@ -40,12 +44,12 @@ function ConvertTo-TppCodeSignEnvironment {
             }
         },
         @{
-            n = 'Name'
-            e = { Split-Path $_.DN -Leaf }
-        },
-        @{
             n = 'TypeName'
             e = { $_.Type }
+        },
+        @{
+            n = 'Guid'
+            e = { [guid] $_.Guid }
         },
         @{
             n = 'OrganizationalUnit'
@@ -106,7 +110,7 @@ function ConvertTo-TppCodeSignEnvironment {
         @{
             n = 'Country'
             e = { $_.Country.Value }
-        }
+        }, AllowUserKeyImport, Disabled, Id, CertificateStatus, CertificateStatusText, CertificateTemplate, SynchronizeChain
 
     }
 }

--- a/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignProject.ps1
@@ -32,8 +32,8 @@ function ConvertTo-TppCodeSignProject {
     }
 
     process {
-        $InputObject | Select-Object
-        -Property @{
+        $InputObject | Select-Object -Property `
+        @{
             n = 'Name'
             e = { Split-Path $_.DN -Leaf }
         },
@@ -44,6 +44,10 @@ function ConvertTo-TppCodeSignProject {
         @{
             n = 'TypeName'
             e = { 'Code Signing Project' }
+        },
+        @{
+            n = 'Guid'
+            e = { [guid] $_.Guid }
         },
         @{
             n = 'Status'
@@ -80,6 +84,6 @@ function ConvertTo-TppCodeSignProject {
         @{
             n = 'CertificateEnvironment'
             e = { $_.CertificateEnvironments | ConvertTo-TppCodeSignEnvironment }
-        }, CreatedOn, Description, Guid, Id
+        }, CreatedOn, Description, Id
     }
 }

--- a/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignProject.ps1
@@ -1,12 +1,12 @@
 <#
 .SYNOPSIS
-Convert code sign certificate environment to something powershell friendly
+Convert code sign project to something powershell friendly
 
 .DESCRIPTION
-Convert code sign certificate environment to something powershell friendly
+Convert code sign project to something powershell friendly
 
 .PARAMETER InputObject
-Code sign certificate environment object
+Code sign project object
 
 .INPUTS
 InputObject
@@ -15,7 +15,7 @@ InputObject
 PSCustomObject
 
 .EXAMPLE
-$envObj | ConvertTo-TppCodeSignEnvironment
+$envObj | ConvertTo-TppCodeSignProject
 
 #>
 function ConvertTo-TppCodeSignProject {

--- a/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Private/ConvertTo-TppCodeSignProject.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+Convert code sign certificate environment to something powershell friendly
+
+.DESCRIPTION
+Convert code sign certificate environment to something powershell friendly
+
+.PARAMETER InputObject
+Code sign certificate environment object
+
+.INPUTS
+InputObject
+
+.OUTPUTS
+PSCustomObject
+
+.EXAMPLE
+$envObj | ConvertTo-TppCodeSignEnvironment
+
+#>
+function ConvertTo-TppCodeSignProject {
+
+    [CmdletBinding()]
+
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
+        [PSCustomObject] $InputObject
+    )
+
+    begin {
+    }
+
+    process {
+        $InputObject | Select-Object
+        -Property @{
+            n = 'Name'
+            e = { Split-Path $_.DN -Leaf }
+        },
+        @{
+            n = 'Path'
+            e = { $_.DN }
+        },
+        @{
+            n = 'TypeName'
+            e = { 'Code Signing Project' }
+        },
+        @{
+            n = 'Status'
+            e = { [enum]::GetName([TppCodeSignProjectStatus], $_.Status) }
+        },
+        @{
+            n = 'ApplicationPath'
+            e = { @($_.ApplicationDNs.Items) }
+        },
+        @{
+            n = 'Application'
+            e = { @($_.Applications) }
+        },
+        @{
+            n = 'Auditor'
+            e = { @($_.Auditors.Items) }
+        },
+        @{
+            n = 'Collection'
+            e = { @($_.Collections) }
+        },
+        @{
+            n = 'KeyUseApprover'
+            e = { @($_.KeyUseApprovers.Items) }
+        },
+        @{
+            n = 'KeyUser'
+            e = { @($_.KeyUsers.Items) }
+        },
+        @{
+            n = 'Owner'
+            e = { @($_.Owners.Items) }
+        },
+        @{
+            n = 'CertificateEnvironment'
+            e = { $_.CertificateEnvironments | ConvertTo-TppCodeSignEnvironment }
+        }, CreatedOn, Description, Guid, Id
+    }
+}

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+Remove sensitive information when writing verbose info
+
+.DESCRIPTION
+Remove sensitive information when writing verbose info
+
+.PARAMETER InputObject
+JSON string or other object
+
+.PARAMETER SecretName
+Name of secret(s) to hide their values.  Default value is 'Password', 'AccessToken', 'RefreshToken'
+
+.INPUTS
+InputObject
+
+.OUTPUTS
+None
+
+.EXAMPLE
+@{'password'='foobar'} | Write-VerboseWithSecret
+Hide password value from hashtable
+
+.EXAMPLE
+$jsonString | Write-VerboseWithSecret
+Hide value(s) from JSON string
+
+#>
+function Write-VerboseWithSecret {
+
+    [CmdletBinding()]
+
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [psobject] $InputObject,
+
+        [Parameter()]
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken')
+    )
+
+    begin {
+    }
+
+    process {
+        if ( -not $InputObject ) {
+            return
+        }
+
+        Write-Debug ('Write-VerboseWithSecret input type: {0}' -f $InputObject.GetType().FullName)
+
+        # default to json string
+        $processMe = $InputObject
+        if ($InputObject.GetType().FullName -ne 'System.String') {
+            # if hashtable or other object, convert to json first
+            $processMe = $InputObject | ConvertTo-Json -Depth 5
+        }
+
+        foreach ($prop in $PropertyName) {
+            # look for secret name and replace value if found
+            if ( $processMe -match "(?s).*\\""$prop\\"": \\""(.*?)\\"".*" ) {
+                $secret = $processMe -replace "(?s).*\\""$prop\\"": \\""(.*?)\\"".*", '$1'
+                $processMe = ($processMe -replace $secret, '***hidden***')
+            }
+        }
+
+        Write-Verbose $processMe
+
+    }
+}

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -37,7 +37,7 @@ function Write-VerboseWithSecret {
         [psobject] $InputObject,
 
         [Parameter()]
-        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token')
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization')
     )
 
     begin {
@@ -59,9 +59,17 @@ function Write-VerboseWithSecret {
 
         foreach ($prop in $PropertyName) {
             # look for secret name and replace value if found
+
+            # look for values in multiline json string, eg. "Body": "{\r\n  \"Password\": \"MyPass\"\r\n}"
             if ( $processMe -match "(?s).*\\""$prop\\"": \\""(.*?)\\"".*" ) {
                 $secret = $processMe -replace "(?s).*\\""$prop\\"": \\""(.*?)\\"".*", '$1'
-                $processMe = ($processMe -replace $secret, '***hidden***')
+                $processMe = ($processMe -replace "$secret", '***hidden***')
+            }
+
+            # look for values in standard key:value string, eg. "Authorization": "Bearer adflkjandsfsmmmsdfkhsdf=="
+            if ( $processMe -match "(?s).*""$prop"": ""(.*?)"".*" ) {
+                $secret = $processMe -replace "(?s).*""$prop"": ""(.*?)"".*", '$1'
+                $processMe = ($processMe -replace "$secret", '***hidden***')
             }
         }
 

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -61,14 +61,18 @@ function Write-VerboseWithSecret {
             # look for secret name and replace value if found
 
             # look for values in multiline json string, eg. "Body": "{\r\n  \"Password\": \"MyPass\"\r\n}"
-            if ( $processMe -match "(?s).*\\""$prop\\"": \\""(.*?)\\"".*" ) {
-                $secret = $processMe -replace "(?s).*\\""$prop\\"": \\""(.*?)\\"".*", '$1'
+            # PS v5 has 2 spaces between \"key\":  \"value\"
+            # PS v7 has 1 space between \"key\": \"value\"
+            if ( $processMe -match "(?s).*\\""$prop\\"": {1,2}\\""(.*?)\\"".*" ) {
+                $secret = $processMe -replace "(?s).*\\""$prop\\"": {1,2}\\""(.*?)\\"".*", '$1'
                 $processMe = ($processMe.replace($secret, '***hidden***'))
             }
 
             # look for values in standard key:value string, eg. "Authorization": "Bearer adflkjandsfsmmmsdfkhsdf=="
-            if ( $processMe -match "(?s).*""$prop"": ""(.*?)"".*" ) {
-                $secret = $processMe -replace "(?s).*""$prop"": ""(.*?)"".*", '$1'
+            # PS v5 has 2 spaces between key:  value
+            # PS v7 has 1 space between key: value
+            if ( $processMe -match "(?s).*""$prop"": {1,2}""(.*?)"".*" ) {
+                $secret = $processMe -replace "(?s).*""$prop"": {1,2}""(.*?)"".*", '$1'
                 $processMe = ($processMe.replace($secret, '***hidden***'))
             }
         }

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -63,13 +63,13 @@ function Write-VerboseWithSecret {
             # look for values in multiline json string, eg. "Body": "{\r\n  \"Password\": \"MyPass\"\r\n}"
             if ( $processMe -match "(?s).*\\""$prop\\"": \\""(.*?)\\"".*" ) {
                 $secret = $processMe -replace "(?s).*\\""$prop\\"": \\""(.*?)\\"".*", '$1'
-                $processMe = ($processMe -replace "$secret", '***hidden***')
+                $processMe = ($processMe.replace($secret, '***hidden***'))
             }
 
             # look for values in standard key:value string, eg. "Authorization": "Bearer adflkjandsfsmmmsdfkhsdf=="
             if ( $processMe -match "(?s).*""$prop"": ""(.*?)"".*" ) {
                 $secret = $processMe -replace "(?s).*""$prop"": ""(.*?)"".*", '$1'
-                $processMe = ($processMe -replace "$secret", '***hidden***')
+                $processMe = ($processMe.replace($secret, '***hidden***'))
             }
         }
 

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -9,7 +9,7 @@ Remove sensitive information when writing verbose info
 JSON string or other object
 
 .PARAMETER SecretName
-Name of secret(s) to hide their values.  Default value is 'Password', 'AccessToken', 'RefreshToken', 'access_token', 'refresh_token'
+Name of secret(s) to hide their values.  Default value is 'Password', 'AccessToken', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization'
 
 .INPUTS
 InputObject

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -61,18 +61,11 @@ function Write-VerboseWithSecret {
             # look for secret name and replace value if found
 
             # look for values in multiline json string, eg. "Body": "{\r\n  \"Password\": \"MyPass\"\r\n}"
-            # PS v5 has 2 spaces between \"key\":  \"value\"
-            # PS v7 has 1 space between \"key\": \"value\"
-            if ( $processMe -match "(?s).*\\""$prop\\"": *\\""(.*?)\\"".*" ) {
-                $secret = $processMe -replace "(?s).*\\""$prop\\"": *\\""(.*?)\\"".*", '$1'
-                $processMe = ($processMe.replace($secret, '***hidden***'))
-            }
-
-            # look for values in standard key:value string, eg. "Authorization": "Bearer adflkjandsfsmmmsdfkhsdf=="
+            # look for values in standard key:value pair, eg. "Authorization": "Bearer adflkjandsfsmmmsdfkhsdf=="
             # PS v5 has 2 spaces between "key":  "value"
             # PS v7 has 1 space between "key": "value"
-            if ( $processMe -match "(?s).*""$prop"": *""(.*?)"".*" ) {
-                $secret = $processMe -replace "(?s).*""$prop"": *""(.*?)"".*", '$1'
+            if ( $processMe -match "(?s).*\\{0,1}""$prop\\{0,1}"": {1,2}\\{0,1}""(.*?)\\{0,1}"".*" ) {
+                $secret = $processMe -replace "(?s).*\\{0,1}""$prop\\{0,1}"": {1,2}\\{0,1}""(.*?)\\{0,1}"".*", '$1'
                 $processMe = ($processMe.replace($secret, '***hidden***'))
             }
         }

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -9,7 +9,7 @@ Remove sensitive information when writing verbose info
 JSON string or other object
 
 .PARAMETER SecretName
-Name of secret(s) to hide their values.  Default value is 'Password', 'AccessToken', 'RefreshToken'
+Name of secret(s) to hide their values.  Default value is 'Password', 'AccessToken', 'RefreshToken', 'access_token', 'refresh_token'
 
 .INPUTS
 InputObject
@@ -37,7 +37,7 @@ function Write-VerboseWithSecret {
         [psobject] $InputObject,
 
         [Parameter()]
-        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken')
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token')
     )
 
     begin {

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -63,16 +63,16 @@ function Write-VerboseWithSecret {
             # look for values in multiline json string, eg. "Body": "{\r\n  \"Password\": \"MyPass\"\r\n}"
             # PS v5 has 2 spaces between \"key\":  \"value\"
             # PS v7 has 1 space between \"key\": \"value\"
-            if ( $processMe -match "(?s).*\\""$prop\\"": {1,2}\\""(.*?)\\"".*" ) {
-                $secret = $processMe -replace "(?s).*\\""$prop\\"": {1,2}\\""(.*?)\\"".*", '$1'
+            if ( $processMe -match "(?s).*\\""$prop\\"": *\\""(.*?)\\"".*" ) {
+                $secret = $processMe -replace "(?s).*\\""$prop\\"": *\\""(.*?)\\"".*", '$1'
                 $processMe = ($processMe.replace($secret, '***hidden***'))
             }
 
             # look for values in standard key:value string, eg. "Authorization": "Bearer adflkjandsfsmmmsdfkhsdf=="
-            # PS v5 has 2 spaces between key:  value
-            # PS v7 has 1 space between key: value
-            if ( $processMe -match "(?s).*""$prop"": {1,2}""(.*?)"".*" ) {
-                $secret = $processMe -replace "(?s).*""$prop"": {1,2}""(.*?)"".*", '$1'
+            # PS v5 has 2 spaces between "key":  "value"
+            # PS v7 has 1 space between "key": "value"
+            if ( $processMe -match "(?s).*""$prop"": *""(.*?)"".*" ) {
+                $secret = $processMe -replace "(?s).*""$prop"": *""(.*?)"".*", '$1'
                 $processMe = ($processMe.replace($secret, '***hidden***'))
             }
         }

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
@@ -37,7 +37,7 @@ function Find-TppCodeSignEnvironment {
     [CmdletBinding(DefaultParameterSetName = 'All')]
     param (
         [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'Name')]
-        [String[]] $Name,
+        [String] $Name,
 
         [Parameter()]
         [TppSession] $TppSession = $Script:TppSession
@@ -52,10 +52,7 @@ function Find-TppCodeSignEnvironment {
 
         Switch ($PsCmdlet.ParameterSetName)	{
             'Name' {
-                $envs = $Name.ForEach{
-                    $thisEnvName = $_
-                    $projects.CertificateEnvironment | Where-Object { $_.Name -match $thisEnvName }
-                }
+                $projects.CertificateEnvironment | Where-Object { $_.Name -match $Name }
                 $envs = $envs | Sort-Object -Property Path -Unique
             }
 

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
@@ -52,7 +52,7 @@ function Find-TppCodeSignEnvironment {
 
         Switch ($PsCmdlet.ParameterSetName)	{
             'Name' {
-                $projects.CertificateEnvironment | Where-Object { $_.Name -match $Name }
+                $envs = $projects.CertificateEnvironment | Where-Object { $_.Name -match $Name }
                 $envs = $envs | Sort-Object -Property Path -Unique
             }
 

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+Search for code sign environments
+
+.DESCRIPTION
+Search for specific code sign environments that match a name you provide or get all.  This will search across projects.
+
+.PARAMETER Name
+Name of the environment to search for
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+None
+
+.OUTPUTS
+TppObject
+
+.EXAMPLE
+Find-TppCodeSignEnvironment
+Get all code sign environments
+
+.EXAMPLE
+Find-TppCodeSignEnvironment -Name Development
+Find all environments that match the name Development
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignEnvironment/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+
+#>
+function Find-TppCodeSignEnvironment {
+
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [String[]] $Name,
+
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate($true)
+        $projects = Find-TppCodeSignProject | Get-TppCodeSignProject
+    }
+
+    process {
+
+        Switch ($PsCmdlet.ParameterSetName)	{
+            'Name' {
+                $envs = $Name.ForEach{
+                    $thisEnvName = $_
+                    $projects.CertificateEnvironment | Where-Object { $_.Name -match $thisEnvName }
+                }
+                $envs = $envs | Sort-Object -Property Path -Unique
+            }
+
+            'All' {
+                $envs = $projects.CertificateEnvironment
+            }
+        }
+
+        if ( $envs ) {
+            foreach ($env in $envs) {
+                [TppObject] @{
+                    Name     = $env.Name
+                    TypeName = $env.TypeName
+                    Path     = $env.Path
+                    Guid     = $env.Guid
+                }
+            }
+        }
+
+    }
+}

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
@@ -35,6 +35,8 @@ https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find
 function Find-TppCodeSignEnvironment {
 
     [CmdletBinding(DefaultParameterSetName = 'All')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '',	Justification = 'Param is being used, possible pssa bug?')]
+
     param (
         [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'Name')]
         [String] $Name,

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
@@ -36,7 +36,7 @@ function Find-TppCodeSignEnvironment {
 
     [CmdletBinding(DefaultParameterSetName = 'All')]
     param (
-        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'Name')]
         [String[]] $Name,
 
         [Parameter()]
@@ -64,16 +64,13 @@ function Find-TppCodeSignEnvironment {
             }
         }
 
-        if ( $envs ) {
-            foreach ($env in $envs) {
-                [TppObject] @{
-                    Name     = $env.Name
-                    TypeName = $env.TypeName
-                    Path     = $env.Path
-                    Guid     = $env.Guid
-                }
+        foreach ($env in $envs) {
+            [TppObject] @{
+                Name     = $env.Name
+                TypeName = $env.TypeName
+                Path     = $env.Path
+                Guid     = $env.Guid
             }
         }
-
     }
 }

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
@@ -73,7 +73,7 @@ function Find-TppCodeSignProject {
             foreach ($project in $response.Projects) {
                 [TppObject] @{
                     Name     = Split-Path $project.DN -Leaf
-                    TypeName = 'SignProject'
+                    TypeName = 'Code Signing Project'
                     Path     = $project.DN
                     Guid     = $project.Guid
                 }

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+Search for code sign projects
+
+.DESCRIPTION
+Search for specific code sign projects or return all
+
+.PARAMETER Name
+Name of the project to search for
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+None
+
+.EXAMPLE
+Find-TppCodeSignProject
+Get all code sign projects
+
+.EXAMPLE
+Find-TppCodeSignProject -Name CSTest
+Find all projects that match the name CSTest
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignProject/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
+
+.LINK
+https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8
+
+#>
+function Find-TppCodeSignProject {
+
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [String[]] $Name,
+
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate($true)
+
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Post'
+            UriLeaf    = 'Codesign/EnumerateProjects'
+            Body       = @{ }
+        }
+    }
+
+    process {
+
+        Switch ($PsCmdlet.ParameterSetName)	{
+            'Name' {
+                $response = $Name.ForEach{
+                    $params.Body.Filter = $_
+                    Invoke-TppRestMethod @params
+                }
+            }
+
+            'All' {
+                $response = Invoke-TppRestMethod @params
+            }
+        }
+
+        if ( $response ) {
+            foreach ($project in $response.Projects) {
+                [TppObject] @{
+                    Name     = Split-Path $project.DN -Leaf
+                    TypeName = 'SignProject'
+                    Path     = $project.DN
+                    Guid     = $project.Guid
+                }
+            }
+        }
+
+    }
+}

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignTemplate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignTemplate.ps1
@@ -32,7 +32,7 @@ https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find
 https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8
 
 #>
-function Find-TppCodeSignProject {
+function Find-TppCodeSignTemplate {
 
     [CmdletBinding(DefaultParameterSetName = 'All')]
     param (
@@ -49,7 +49,7 @@ function Find-TppCodeSignProject {
         $params = @{
             TppSession = $TppSession
             Method     = 'Post'
-            UriLeaf    = 'Codesign/EnumerateProjects'
+            UriLeaf    = 'Codesign/EnumerateTemplates'
             Body       = @{ }
         }
     }
@@ -69,16 +69,16 @@ function Find-TppCodeSignProject {
             }
         }
 
-        $allProjects = foreach ($thisResponse in $response) {
+        $allTemplates = foreach ($thisResponse in $response) {
             if ( $thisResponse.Success ) {
-                $thisProject = $thisResponse.Projects
+                $thisTemplate = $thisResponse.CertificateTemplates
                 # we could be successful without a returned value so check for this
-                if ( $thisProject ) {
+                if ( $thisTemplate ) {
                     [TppObject] @{
-                        Name     = Split-Path $thisProject.DN -Leaf
-                        TypeName = 'Code Signing Project'
-                        Path     = $thisProject.DN
-                        Guid     = $thisProject.Guid
+                        Name     = Split-Path $thisTemplate.DN -Leaf
+                        TypeName = $thisTemplate.Type
+                        Path     = $thisTemplate.DN
+                        Guid     = $thisTemplate.Guid
                     }
                 }
 
@@ -87,6 +87,6 @@ function Find-TppCodeSignProject {
             }
         }
 
-        $allProjects | Sort-Object -Property Path -Unique
+        $allTemplates | Sort-Object -Property Path -Unique
     }
 }

--- a/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1
@@ -22,21 +22,20 @@ InputObject, Path, Guid
 
 .OUTPUTS
 PSCustomObject with the following properties:
+    Name
+    TypeName
     Path
     Guid
+    ParentPath
+    Approver
     CertificateAuthorityDN
     CertificateDetails
-    Consumers
     Contact
     CreatedOn
     CustomFields
-    Description
     ManagementType
-    Name
-    ParentDn
     ProcessingDetails
     RenewalDetails
-    SchemaClass
     ValidationDetails
 
 .EXAMPLE
@@ -50,10 +49,7 @@ http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCertificateDetail/
 https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1
 
 .LINK
-https://docs.venafi.com/Docs/18.1SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-GET-Certificates.php?TocPath=REST%20API%20reference|Certificates%20module%20programming%20interfaces|_____3
-
-.LINK
-https://docs.venafi.com/Docs/18.1SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-GET-Certificates-guid.php?TocPath=REST%20API%20reference|Certificates%20module%20programming%20interfaces|_____5
+https://docs.venafi.com/Docs/20.3SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates-guid.php?tocpath=Web%20SDK%20reference%7CCertificates%20programming%20interface%7C_____10
 
 .LINK
 https://msdn.microsoft.com/en-us/library/system.web.httputility(v=vs.110).aspx

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+Get CodeSign Protect project settings
+
+.DESCRIPTION
+Get CodeSign Protect project settings.  Must have token with scope codesign:manage.
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+None
+
+.OUTPUTS
+PSCustomObject with the following properties:
+    ApprovedKeyStorageLocations
+    AvailableKeyStorageLocations
+    DefaultCAContainer
+    DefaultCertificateContainer
+    DefaultCredentialContainer
+    KeyUseTimeout
+    ProjectDescriptionTooltip
+    RequestInProgressMessage
+
+.EXAMPLE
+Get-TppCodeSignConfig
+Get settings
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignConfig/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1
+
+.LINK
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-GET-Codesign-GetGlobalConfiguration.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CGlobalConfiguration%7C_____1
+
+#>
+function Get-TppCodeSignConfig {
+
+    [CmdletBinding()]
+
+    param (
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate($true)
+
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Get'
+            UriLeaf    = 'Codesign/GetGlobalConfiguration'
+        }
+    }
+
+    process {
+
+        $response = Invoke-TppRestMethod @params
+
+        if ( $response.Success ) {
+            $response.GlobalConfiguration
+        } else {
+            Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+        }
+    }
+}

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
@@ -49,7 +49,7 @@ https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10
 
 #>
-function Get-TppCodeSignProject {
+function Get-TppCodeSignEnvironment {
 
     [CmdletBinding()]
     param (
@@ -74,7 +74,7 @@ function Get-TppCodeSignProject {
         $params = @{
             TppSession = $TppSession
             Method     = 'Post'
-            UriLeaf    = 'Codesign/GetProject'
+            UriLeaf    = 'Codesign/GetEnvironment'
             Body       = @{ }
         }
     }
@@ -85,47 +85,7 @@ function Get-TppCodeSignProject {
         $response = Invoke-TppRestMethod @params
 
         if ( $response.Success ) {
-            $response.Project | Select-Object -ExcludeProperty DN, ApplicationDNs, Auditors, KeyUseApprovers, KeyUsers, Owners, Status, CertificateEnvironments -Property *,
-            @{
-                n = 'Name'
-                e = { Split-Path $_.DN -Leaf }
-            },
-            @{
-                n = 'Path'
-                e = { $_.DN }
-            },
-            @{
-                n = 'TypeName'
-                e = { 'Code Signing Project' }
-            },
-            @{
-                n = 'Status'
-                e = { [enum]::GetName([TppCodeSignStatus], $_.Status) }
-            },
-            @{
-                n = 'ApplicationPath'
-                e = { @($_.ApplicationDNs.Items) }
-            },
-            @{
-                n = 'Auditor'
-                e = { @($_.Auditors.Items) }
-            },
-            @{
-                n = 'KeyUseApprover'
-                e = { @($_.KeyUseApprovers.Items) }
-            },
-            @{
-                n = 'KeyUser'
-                e = { @($_.KeyUsers.Items) }
-            },
-            @{
-                n = 'Owner'
-                e = { @($_.Owners.Items) }
-            },
-            @{
-                n = 'CertificateEnvironment'
-                e = { $_.CertificateEnvironments | ConvertTo-TppCodeSignEnvironment }
-            }
+            $response.CertificateEnvironment | ConvertTo-TppCodeSignEnvironment
         } else {
             Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
         }

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
@@ -1,12 +1,12 @@
 <#
 .SYNOPSIS
-Get a code sign project
+Get a code sign environment
 
 .DESCRIPTION
-Get code sign project details
+Get code sign environment details
 
 .PARAMETER Path
-Path of the project to get
+Path of the environment to get
 
 .PARAMETER TppSession
 Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
@@ -16,37 +16,49 @@ Path
 
 .OUTPUTS
 PSCustomObject with the following properties:
-    Applications
-    Auditor
-    CertificateEnvironments
-    Collections
-    CreatedOn
+    AllowUserKeyImport
+    Disabled
     Guid
     Id
-    KeyUseApprovers
-    KeyUsers
-    Owners
-    Status
-    Name
+    CertificateStatus
+    CertificateStatusText
+    CertificateTemplate
+    SynchronizeChain
     Path
+    Name
     TypeName
+    OrganizationalUnit
+    IPAddressRestriction
+    KeyUseFlowPath
+    TemplatePath
+    CertificateAuthorityPath
+    CertificatePath
+    CertificateSubject
+    City
+    KeyAlgorithm
+    KeyStorageLocation
+    Organization
+    OrganizationUnit
+    SANEmail
+    State
+    Country
 
 .EXAMPLE
-Get-TppCodeSignProject -Path '\ved\code signing\projects\my_project'
-Get a code sign project
+Get-TppCodeSignEnvironment -Path '\ved\code signing\projects\my_project\my_env'
+Get a code sign environment
 
 .EXAMPLE
-$projectObj | Get-TppCodeSignProject
-Get a project after searching using Find-TppCodeSignProject
+$envObj | Get-TppCodeSignEnvironment
+Get a environment after searching using Find-TppCodeSignEnvironment
 
 .LINK
-http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignProject/
+http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignEnvironment/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
 
 .LINK
-https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____9
 
 #>
 function Get-TppCodeSignEnvironment {

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
@@ -97,6 +97,7 @@ function Get-TppCodeSignEnvironment {
         $response = Invoke-TppRestMethod @params
 
         if ( $response.Success ) {
+            Write-Debug $response.CertificateEnvironment
             $response.CertificateEnvironment | ConvertTo-TppCodeSignEnvironment
         } else {
             Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
@@ -18,14 +18,14 @@ Path
 PSCustomObject with the following properties:
     Application
     Auditor
-    CertificateEnvironments
+    CertificateEnvironment
     Collection
     CreatedOn
     Guid
     Id
-    KeyUseApprovers
-    KeyUsers
-    Owners
+    KeyUseApprover
+    KeyUser
+    Owner
     Status
     Name
     Path
@@ -85,6 +85,7 @@ function Get-TppCodeSignProject {
         $response = Invoke-TppRestMethod @params
 
         if ( $response.Success ) {
+            Write-Debug $response.Project
             $response.Project | ConvertTo-TppCodeSignProject
         } else {
             Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+Get a code sign project
+
+.DESCRIPTION
+Get code sign project details
+
+.PARAMETER Path
+Path of the project to get
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+Path
+
+.OUTPUTS
+PSCustomObject with the following properties:
+    ApplicationDNs
+    Applications
+    Auditors
+    CertificateEnvironments
+    Collections
+    CreatedOn
+    Guid
+    Id
+    KeyUseApprovers
+    KeyUsers
+    Owners
+    Status
+    Name
+    Path
+    TypeName
+
+.EXAMPLE
+Get-TppCodeSignProject -Path '\ved\code signing\projects\my_project'
+Get a code sign project
+
+.EXAMPLE
+$projectObj | Get-TppCodeSignProject
+Get a project after searching using Find-TppCodeSignProject
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignProject/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+
+.LINK
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10
+
+#>
+function Get-TppCodeSignProject {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {
+                if ( $_ | Test-TppDnPath ) {
+                    $true
+                } else {
+                    throw "'$_' is not a valid path"
+                }
+            })]
+        [Alias('DN')]
+        [String] $Path,
+
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate($true)
+
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Post'
+            UriLeaf    = 'Codesign/GetProject'
+            Body       = @{ }
+        }
+    }
+
+    process {
+
+        $params.Body.Dn = $Path
+        $response = Invoke-TppRestMethod @params
+
+        if ( $response.Success ) {
+            $response.Project | Select-Object -ExcludeProperty DN -Property *,
+            @{
+                n = 'Name'
+                e = { Split-Path $_.DN -Leaf }
+            },
+            @{
+                n = 'Path'
+                e = { $_.DN }
+            },
+            @{
+                n = 'TypeName'
+                e = { 'SignProject' }
+            }
+        } else {
+            Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+        }
+    }
+}

--- a/VenafiTppPS/Code/Public/Invoke-TppRestMethod.ps1
+++ b/VenafiTppPS/Code/Public/Invoke-TppRestMethod.ps1
@@ -121,8 +121,8 @@ function Invoke-TppRestMethod {
     if ( $PSBoundParameters.ContainsKey('UseWebRequest') ) {
         Write-Debug "Using Invoke-WebRequest"
         try {
-            Invoke-WebRequest @params
-            # $verboseOutput = $(Invoke-WebRequest @params) 4>&1
+            # Invoke-WebRequest @params
+            $verboseOutput = $($response = Invoke-WebRequest @params) 4>&1
         } catch {
             $_.Exception.Response
         }
@@ -131,8 +131,6 @@ function Invoke-TppRestMethod {
         try {
             # Invoke-RestMethod @params
             $verboseOutput = $($response = Invoke-RestMethod @params) 4>&1
-            # Write-Warning $verboseOutput
-            # Write-Warning $response
         } catch {
             # try with trailing slash as some GETs return a 307/401 without it
             if ( -not $uri.EndsWith('/') ) {
@@ -142,8 +140,8 @@ function Invoke-TppRestMethod {
                 $params.Uri += '/'
 
                 try {
-                    Invoke-RestMethod @params
-                    # $verboseOutput = $(Invoke-RestMethod @params) 4>&1
+                    # Invoke-RestMethod @params
+                    $verboseOutput = $($response = Invoke-RestMethod @params) 4>&1
                     Write-Warning ('{0} call requires a trailing slash, please create an issue at https://github.com/gdbarron/VenafiTppPS/issues and mention api endpoint {1}' -f $Method, ('{1}/{2}' -f $UriRoot, $UriLeaf))
                 } catch {
                     throw ('"{0} {1}: {2}' -f $_.Exception.Response.StatusCode.value__, $_.Exception.Response.StatusDescription, $_ | Out-String )

--- a/VenafiTppPS/Code/Public/Invoke-TppRestMethod.ps1
+++ b/VenafiTppPS/Code/Public/Invoke-TppRestMethod.ps1
@@ -115,19 +115,24 @@ function Invoke-TppRestMethod {
         $params.Add('UseDefaultCredentials', $true)
     }
 
-    Write-Verbose ($params | ConvertTo-Json | Out-String)
+    # Write-Verbose ($params | ConvertTo-Json | Out-String)
+    $params | Write-VerboseWithSecret
 
     if ( $PSBoundParameters.ContainsKey('UseWebRequest') ) {
         Write-Debug "Using Invoke-WebRequest"
         try {
             Invoke-WebRequest @params
+            # $verboseOutput = $(Invoke-WebRequest @params) 4>&1
         } catch {
             $_.Exception.Response
         }
     } else {
         Write-Debug "Using Invoke-RestMethod"
         try {
-            Invoke-RestMethod @params
+            # Invoke-RestMethod @params
+            $verboseOutput = $($response = Invoke-RestMethod @params) 4>&1
+            # Write-Warning $verboseOutput
+            # Write-Warning $response
         } catch {
             # try with trailing slash as some GETs return a 307/401 without it
             if ( -not $uri.EndsWith('/') ) {
@@ -138,6 +143,7 @@ function Invoke-TppRestMethod {
 
                 try {
                     Invoke-RestMethod @params
+                    # $verboseOutput = $(Invoke-RestMethod @params) 4>&1
                     Write-Warning ('{0} call requires a trailing slash, please create an issue at https://github.com/gdbarron/VenafiTppPS/issues and mention api endpoint {1}' -f $Method, ('{1}/{2}' -f $UriRoot, $UriLeaf))
                 } catch {
                     throw ('"{0} {1}: {2}' -f $_.Exception.Response.StatusCode.value__, $_.Exception.Response.StatusDescription, $_ | Out-String )
@@ -147,5 +153,7 @@ function Invoke-TppRestMethod {
             }
         }
     }
-}
 
+    $verboseOutput.Message | Write-VerboseWithSecret
+    $response
+}

--- a/VenafiTppPS/Code/Public/Invoke-TppRestMethod.ps1
+++ b/VenafiTppPS/Code/Public/Invoke-TppRestMethod.ps1
@@ -103,7 +103,7 @@ function Invoke-TppRestMethod {
         ContentType = 'application/json'
     }
 
-    if ( $Body.Count -gt 0 ) {
+    if ( $Body ) {
         $restBody = $Body
         if ( $Method -ne 'Get' ) {
             $restBody = ConvertTo-Json $Body -depth 5

--- a/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
@@ -47,7 +47,7 @@ https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-
 #>
 function New-TppCodeSignProject {
 
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
@@ -78,12 +78,15 @@ function New-TppCodeSignProject {
     process {
 
         $params.Body.Dn = $Path
-        $response = Invoke-TppRestMethod @params
 
-        if ( $response.Success ) {
-            $response.Project | ConvertTo-TppCodeSignProject
-        } else {
-            Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+        if ( $PSCmdlet.ShouldProcess($Path, 'New code sign project') ) {
+            $response = Invoke-TppRestMethod @params
+
+            if ( $response.Success ) {
+                $response.Project | ConvertTo-TppCodeSignProject
+            } else {
+                Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+            }
         }
     }
 }

--- a/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
@@ -1,12 +1,12 @@
 <#
 .SYNOPSIS
-Get a code sign project
+Create a new code sign project
 
 .DESCRIPTION
-Get code sign project details
+Create a new code sign project which will be empty.
 
 .PARAMETER Path
-Path of the project to get
+Path of the project to create
 
 .PARAMETER TppSession
 Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
@@ -32,28 +32,24 @@ PSCustomObject with the following properties:
     TypeName
 
 .EXAMPLE
-Get-TppCodeSignProject -Path '\ved\code signing\projects\my_project'
-Get a code sign project
-
-.EXAMPLE
-$projectObj | Get-TppCodeSignProject
-Get a project after searching using Find-TppCodeSignProject
+New-TppCodeSignProject -Path '\ved\code signing\projects\my_project'
+Create a new code sign project
 
 .LINK
-http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignProject/
+http://venafitppps.readthedocs.io/en/latest/functions/New-TppCodeSignProject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
 
 .LINK
-https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-CreateProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____5
 
 #>
-function Get-TppCodeSignProject {
+function New-TppCodeSignProject {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
@@ -74,7 +70,7 @@ function Get-TppCodeSignProject {
         $params = @{
             TppSession = $TppSession
             Method     = 'Post'
-            UriLeaf    = 'Codesign/GetProject'
+            UriLeaf    = 'Codesign/CreateProject'
             Body       = @{ }
         }
     }

--- a/VenafiTppPS/Code/Public/New-TppSession.ps1
+++ b/VenafiTppPS/Code/Public/New-TppSession.ps1
@@ -26,7 +26,7 @@ Hashtable with Scopes and privilege restrictions.
 The key is the scope and the value is one or more privilege restrictions separated by commas, @{'certificate'='delete,manage'}.
 Scopes include Agent, Certificate, Code Signing, Configuration, Restricted, Security, SSH, and statistics.
 For no privilege restriction or read access, use a value of $null.
-For a scope <-> privilege map, see the 'WEB SDK' section @ https://docs.venafi.com/Docs/20.1/TopNav/Content/SDK/AuthSDK/r-SDKa-OAuthScopePrivilegeMapping.php?tocpath=Topics%20by%20Guide%7CDeveloper%27s%20Guide%7CAuth%20SDK%20reference%20for%20token%20management%7C_____6.
+For a scope to privilege mapping, see https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/AuthSDK/r-SDKa-OAuthScopePrivilegeMapping.php?tocpath=Auth%20SDK%20reference%20for%20token%20management%7C_____5
 
 .PARAMETER State
 A session state, redirect URL, or random string to prevent Cross-Site Request Forgery (CSRF) attacks

--- a/VenafiTppPS/Code/Public/New-TppSession.ps1
+++ b/VenafiTppPS/Code/Public/New-TppSession.ps1
@@ -245,9 +245,10 @@ function New-TppSession {
         # this isn't required so bypass on failure
         $newSession.Version = (Get-TppVersion -TppSession $newSession -ErrorAction SilentlyContinue)
 
-        $allFields = (Get-TppCustomField -TppSession $newSession -Class 'X509 Certificate').Items
-        $deviceFields = (Get-TppCustomField -TppSession $newSession -Class 'Device').Items
-        $allFields += $deviceFields | Where-Object { $_.Guid -notin $allFields.Guid }
+        $certFields = Get-TppCustomField -TppSession $newSession -Class 'X509 Certificate' -ErrorAction SilentlyContinue
+        $deviceFields = Get-TppCustomField -TppSession $newSession -Class 'Device' -ErrorAction SilentlyContinue
+        $allFields = $certFields.Items
+        $allFields += $deviceFields.Items | Where-Object { $_.Guid -notin $allFields.Guid }
         $newSession.CustomField = $allFields
 
         if ( $PassThru ) {

--- a/VenafiTppPS/Code/Public/New-TppToken.ps1
+++ b/VenafiTppPS/Code/Public/New-TppToken.ps1
@@ -143,7 +143,7 @@ function New-TppToken {
 
         $response = Invoke-TppRestMethod @params
 
-        Write-Verbose ($response | Out-String)
+        $response | Write-VerboseWithSecret
 
         [PSCustomObject] @{
             AuthUrl      = $AuthUrl

--- a/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+Delete a code sign certificate environment
+
+.DESCRIPTION
+Delete a code sign certificate environment and related objects such as keys and certificates. You must be a code sign admin or owner of the project.
+
+.PARAMETER Path
+Path of the environment to delete
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+Path
+
+.OUTPUTS
+None
+
+.EXAMPLE
+Remove-TppCodeSignEnvironment -Path '\ved\code signing\projects\my_project\dev'
+Delete an environment
+
+.EXAMPLE
+$envObj | Remove-TppCodeSignEnvironment
+Remove 1 or more environments.  Get environments with Find-TppCodeSignEnvironment
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignEnvironment/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1
+
+.LINK
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____6
+
+#>
+function Remove-TppCodeSignEnvironment {
+
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {
+                if ( $_ | Test-TppDnPath ) {
+                    $true
+                } else {
+                    throw "'$_' is not a valid path"
+                }
+            })]
+        [String] $Path,
+
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate($true)
+
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Post'
+            UriLeaf    = 'Codesign/DeleteEnvironment'
+            Body       = @{ }
+        }
+    }
+
+    process {
+
+        $params.Body.Dn = $Path
+
+        if ( $PSCmdlet.ShouldProcess($Path, 'Remove code sign certificate environment') ) {
+
+            $response = Invoke-TppRestMethod @params
+
+            if ( -not $response.Success ) {
+                Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+            }
+        }
+    }
+}

--- a/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+Delete a code sign project
+
+.DESCRIPTION
+Delete a code sign project.  You must be a code sign admin or owner of the project.
+
+.PARAMETER Path
+Path of the project to delete
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+Path
+
+.OUTPUTS
+None
+
+.EXAMPLE
+Remove-TppCodeSignProject -Path '\ved\code signing\projects\my_project'
+Delete a project
+
+.EXAMPLE
+$projectObj | Remove-TppCodeSignProject
+Remove 1 or more projects.  Get projects with Find-TppCodeSignProject
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignProject/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1
+
+.LINK
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____7
+
+#>
+function Remove-TppCodeSignProject {
+
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {
+                if ( $_ | Test-TppDnPath ) {
+                    $true
+                } else {
+                    throw "'$_' is not a valid path"
+                }
+            })]
+        [String] $Path,
+
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate($true)
+
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Post'
+            UriLeaf    = 'Codesign/DeleteProject'
+            Body       = @{ }
+        }
+    }
+
+    process {
+
+        $params.Body.Dn = $Path
+
+        if ( $PSCmdlet.ShouldProcess($Path, 'Remove code sign project') ) {
+
+            $response = Invoke-TppRestMethod @params
+
+            if ( -not $response.Success ) {
+                Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+            }
+        }
+    }
+}

--- a/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
+++ b/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
@@ -1,12 +1,15 @@
 <#
 .SYNOPSIS
-Get a code sign project
+Set project status
 
 .DESCRIPTION
-Get code sign project details
+Set project status
 
 .PARAMETER Path
-Path of the project to get
+Path of the project to update
+
+.PARAMETER Status
+New project status, must have the appropriate perms.  Status can be Disabled, Enabled, Draft, or Pending.
 
 .PARAMETER TppSession
 Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
@@ -15,41 +18,23 @@ Session object created from New-TppSession method.  The value defaults to the sc
 Path
 
 .OUTPUTS
-PSCustomObject with the following properties:
-    Application
-    Auditor
-    CertificateEnvironments
-    Collection
-    CreatedOn
-    Guid
-    Id
-    KeyUseApprovers
-    KeyUsers
-    Owners
-    Status
-    Name
-    Path
-    TypeName
+None
 
 .EXAMPLE
-Get-TppCodeSignProject -Path '\ved\code signing\projects\my_project'
-Get a code sign project
-
-.EXAMPLE
-$projectObj | Get-TppCodeSignProject
-Get a project after searching using Find-TppCodeSignProject
+Set-TppCodeSignProject -Path '\ved\code signing\projects\my_project' -Status Pending
+Update project status
 
 .LINK
-http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignProject/
+http://venafitppps.readthedocs.io/en/latest/functions/Set-TppCodeSignProjectStatus/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
 
 .LINK
-https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-UpdateProjectStatus.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____14
 
 #>
-function Get-TppCodeSignProject {
+function Set-TppCodeSignProjectStatus {
 
     [CmdletBinding()]
     param (
@@ -64,6 +49,9 @@ function Get-TppCodeSignProject {
             })]
         [String] $Path,
 
+        [Parameter(Mandatory)]
+        [TppCodeSignProjectStatus] $Status,
+
         [Parameter()]
         [TppSession] $TppSession = $Script:TppSession
     )
@@ -74,8 +62,10 @@ function Get-TppCodeSignProject {
         $params = @{
             TppSession = $TppSession
             Method     = 'Post'
-            UriLeaf    = 'Codesign/GetProject'
-            Body       = @{ }
+            UriLeaf    = 'Codesign/UpdateProjectStatus'
+            Body       = @{
+                'ProjectStatus' = $Status
+            }
         }
     }
 
@@ -84,9 +74,7 @@ function Get-TppCodeSignProject {
         $params.Body.Dn = $Path
         $response = Invoke-TppRestMethod @params
 
-        if ( $response.Success ) {
-            $response.Project | ConvertTo-TppCodeSignProject
-        } else {
+        if ( -not $response.Success ) {
             Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
         }
     }

--- a/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
+++ b/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
@@ -36,7 +36,7 @@ https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-
 #>
 function Set-TppCodeSignProjectStatus {
 
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
@@ -72,10 +72,13 @@ function Set-TppCodeSignProjectStatus {
     process {
 
         $params.Body.Dn = $Path
-        $response = Invoke-TppRestMethod @params
 
-        if ( -not $response.Success ) {
-            Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+        if ( $PSCmdlet.ShouldProcess($Path, "Set project status to $Status") ) {
+            $response = Invoke-TppRestMethod @params
+
+            if ( -not $response.Success ) {
+                Write-Error ('{0} : {1} : {2}' -f $response.Result, [enum]::GetName([TppCodeSignResult], $response.Result), $response.Error)
+            }
         }
     }
 }

--- a/VenafiTppPS/Code/VenafiTppPS.psd1
+++ b/VenafiTppPS/Code/VenafiTppPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VenafiTppPS.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.5'
+ModuleVersion = '2.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -69,21 +69,21 @@ PowerShellVersion = '5.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Add-TppCertificateAssociation', 'ConvertTo-TppGuid', 
-               'ConvertTo-TppPath', 'Find-TppCertificate', 'Find-TppIdentity', 
-               'Find-TppObject', 'Get-TppAttribute', 'Get-TppCertificate', 
-               'Get-TppCertificateDetail', 'Get-TppCustomField', 
-               'Get-TppIdentityAttribute', 'Get-TppObject', 'Get-TppPermission', 
-               'Get-TppSystemStatus', 'Get-TppVersion', 'Get-TppWorkflowTicket', 
-               'Import-TppCertificate', 'Invoke-TppCertificateRenewal', 
-               'Invoke-TppRestMethod', 'Move-TppObject', 'New-TppCapiApplication', 
-               'New-TppCertificate', 'New-TppDevice', 'New-TppObject', 'New-TppPolicy', 
-               'New-TppSession', 'New-TppToken', 'Read-TppLog', 
-               'Remove-TppCertificate', 'Remove-TppCertificateAssociation', 
-               'Rename-TppObject', 'Revoke-TppCertificate', 'Revoke-TppToken', 
-               'Set-TppAttribute', 'Set-TppPermission', 
-               'Set-TppWorkflowTicketStatus', 'Test-TppIdentity', 'Test-TppObject', 
-               'Write-TppLog'
+FunctionsToExport = 'Add-TppCertificateAssociation', 'ConvertTo-TppGuid',
+               'ConvertTo-TppPath', 'Find-TppCertificate', 'Find-TppIdentity',
+               'Find-TppObject', 'Get-TppAttribute', 'Get-TppCertificate',
+               'Get-TppCertificateDetail', 'Get-TppCustomField',
+               'Get-TppIdentityAttribute', 'Get-TppObject', 'Get-TppPermission',
+               'Get-TppSystemStatus', 'Get-TppVersion', 'Get-TppWorkflowTicket',
+               'Import-TppCertificate', 'Invoke-TppCertificateRenewal',
+               'Invoke-TppRestMethod', 'Move-TppObject', 'New-TppCapiApplication',
+               'New-TppCertificate', 'New-TppDevice', 'New-TppObject', 'New-TppPolicy',
+               'New-TppSession', 'New-TppToken', 'Read-TppLog',
+               'Remove-TppCertificate', 'Remove-TppCertificateAssociation',
+               'Rename-TppObject', 'Revoke-TppCertificate', 'Revoke-TppToken',
+               'Set-TppAttribute', 'Set-TppPermission',
+               'Set-TppWorkflowTicketStatus', 'Test-TppIdentity', 'Test-TppObject',
+               'Write-TppLog', 'Get-TppCodeSignConfig', 'Find-TppCodeSignProject', 'Get-TppCodeSignProject', 'Find-TppCodeSignEnvironment', 'Get-TppCodeSignEnvironment', 'Remove-TppCodeSignEnvironment', 'Remove-TppCodeSignProject'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/VenafiTppPS/Code/VenafiTppPS.psd1
+++ b/VenafiTppPS/Code/VenafiTppPS.psd1
@@ -83,7 +83,8 @@ FunctionsToExport = 'Add-TppCertificateAssociation', 'ConvertTo-TppGuid',
                'Rename-TppObject', 'Revoke-TppCertificate', 'Revoke-TppToken',
                'Set-TppAttribute', 'Set-TppPermission',
                'Set-TppWorkflowTicketStatus', 'Test-TppIdentity', 'Test-TppObject',
-               'Write-TppLog', 'Get-TppCodeSignConfig', 'Find-TppCodeSignProject', 'Get-TppCodeSignProject', 'Find-TppCodeSignEnvironment', 'Get-TppCodeSignEnvironment', 'Remove-TppCodeSignEnvironment', 'Remove-TppCodeSignProject'
+               'Write-TppLog', 'Get-TppCodeSignConfig', 'Find-TppCodeSignProject', 'Get-TppCodeSignProject', 'Find-TppCodeSignEnvironment', 'Get-TppCodeSignEnvironment', 'Remove-TppCodeSignEnvironment', 'Remove-TppCodeSignProject',
+               'Find-TppCodeSignTemplate', 'New-TppCodeSignProject', 'Set-TppCodeSignProjectStatus'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
- Update Get-TppCertificateDetail help to ensure output lists the correct properties, [#119](https://github.com/gdbarron/VenafiTppPS/issues/119).  Thanks @doyle043!
- Hide secret info, eg. passwords, tokens, etc, when verbose logging.  [#120](https://github.com/gdbarron/VenafiTppPS/issues/120).  Thanks @bwright86!
- Add search, get, and remove code sign project and environment functions
- Fix, provide the correct error message when making rest call and testing to see if a trailing slash is needed or not
- Update New-TppSession to ensure $TppSession is created even if subsequent custom field calls fail
- Update TppSession object Validate method to check if token auth is required.  Needed for code sign.