### PR TITLE
04-2021 fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix #134, server url is blank when running `Get-TppObject` with secondary token.  This was an issue for Get-TppPermission as well.  Thanks @stevekeever!
 - Add missing parameters comment-based help for `New-TppCapiApplication`
 - Fix certificate push not working in `New-TppCapiApplication`
+- Update links to `main` branch
 
 ## v2.2.0
 - Identity format validation fix, [#126](https://github.com/gdbarron/VenafiTppPS/issues/126).  Thanks @DadsVacayShorts!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix #134, server url is blank when running `Get-TppObject` with secondary token.  This was an issue for Get-TppPermission as well.  Thanks @stevekeever!
 - Add missing parameters comment-based help for `New-TppCapiApplication`
 - Fix certificate push not working in `New-TppCapiApplication`
-- Update links to `main` branch
+- Update links to reference `main` branch instead of `master`
 
 ## v2.2.0
 - Identity format validation fix, [#126](https://github.com/gdbarron/VenafiTppPS/issues/126).  Thanks @DadsVacayShorts!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.2.1
+- Rename 'Provision' to 'Push', aliases added for existing code
+- Add Invoke-TppCertificatePush
+- Fix #130, Get-TppDevice only accepting IP address for host, not hostname.  Thanks @Curtmcgirt!
+- Fix #131, add examples to `New-TppCapiApplication`.  Thanks @Curtmcgirt!
+- Fix #132, 500 error setting BindingIpAddress running `New-TppCapiApplication`.    Thanks @Curtmcgirt!
+- Fix #134, server url is blank when running `Get-TppObject` with secondary token.  This was an issue for Get-TppPermission as well.  Thanks @stevekeever!
+- Add missing parameters comment-based help for `New-TppCapiApplication`
+- Fix certificate push not working in `New-TppCapiApplication`
+
 ## v2.2.0
 - Identity format validation fix, [#126](https://github.com/gdbarron/VenafiTppPS/issues/126).  Thanks @DadsVacayShorts!
 - Add Get-TppIdentity to retrieve Identity info given an id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 2.2.1
 - Rename 'Provision' to 'Push', aliases added for existing code
 - Add Invoke-TppCertificatePush
-- Fix #130, Get-TppDevice only accepting IP address for host, not hostname.  Thanks @Curtmcgirt!
-- Fix #131, add examples to `New-TppCapiApplication`.  Thanks @Curtmcgirt!
-- Fix #132, 500 error setting BindingIpAddress running `New-TppCapiApplication`.    Thanks @Curtmcgirt!
-- Fix #134, server url is blank when running `Get-TppObject` with secondary token.  This was an issue for Get-TppPermission as well.  Thanks @stevekeever!
+- Fix [#130](https://github.com/gdbarron/VenafiTppPS/issues/130), Get-TppDevice only accepting IP address for host, not hostname.  Thanks @Curtmcgirt!
+- Fix [#131](https://github.com/gdbarron/VenafiTppPS/issues/131), add examples to `New-TppCapiApplication`.  Thanks @Curtmcgirt!
+- Fix [#132](https://github.com/gdbarron/VenafiTppPS/issues/132), 500 error setting BindingIpAddress running `New-TppCapiApplication`.    Thanks @Curtmcgirt!
+- Fix [#134](https://github.com/gdbarron/VenafiTppPS/issues/134), server url is blank when running `Get-TppObject` with secondary token.  This was an issue for Get-TppPermission as well.  Thanks @stevekeever!
 - Add missing parameters comment-based help for `New-TppCapiApplication`
 - Fix certificate push not working in `New-TppCapiApplication`
 - Update links to reference `main` branch instead of `master`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,1 +1,1 @@
-https://github.com/gdbarron/VenafiTppPS/blob/master/CHANGELOG.md
+https://github.com/gdbarron/VenafiTppPS/blob/main/CHANGELOG.md

--- a/VenafiTppPS.nuspec
+++ b/VenafiTppPS.nuspec
@@ -6,7 +6,7 @@
     <authors>Greg Brownstein</authors>
     <owners>Greg Brownstein</owners>
     <projectUrl>https://github.com/gdbarron/VenafiTppPS</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/gdbarron/VenafiTppPS/master/images/Ven_circleV_logo.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/gdbarron/VenafiTppPS/main/images/Ven_circleV_logo.png</iconUrl>
     <licenseUrl>https://www.github.com/gdbarron/VenafiTppPS/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>PowerShell module to take advantage of the Venafi TPP REST API</description>

--- a/VenafiTppPS/Code/Classes/TppObject.ps1
+++ b/VenafiTppPS/Code/Classes/TppObject.ps1
@@ -51,8 +51,24 @@ class TppObject {
         $this.TypeName = $info.TypeName
     }
 
+    TppObject ([string] $Path, [PSObject] $TppSession) {
+        $info = $Path | ConvertTo-TppGuid -IncludeType -TppSession $TppSession
+        $this.Path = $Path
+        $this.Name = Split-Path $Path -Leaf
+        $this.Guid = $info.Guid
+        $this.TypeName = $info.TypeName
+    }
+
     TppObject ([guid] $Guid) {
         $info = ConvertTo-TppPath -Guid $Guid -IncludeType
+        $this.Guid = $Guid
+        $this.Name = Split-Path $info.Path -Leaf
+        $this.Path = $info.Path
+        $this.TypeName = $info.TypeName
+    }
+
+    TppObject ([guid] $Guid, [PSObject] $TppSession) {
+        $info = ConvertTo-TppPath -Guid $Guid -IncludeType -TppSession $TppSession
         $this.Guid = $Guid
         $this.Name = Split-Path $info.Path -Leaf
         $this.Path = $info.Path

--- a/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
+++ b/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
@@ -40,7 +40,7 @@ Add the association and push the certificate
 http://venafitppps.readthedocs.io/en/latest/functions/Add-TppCertificateAssociation/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
 
 .LINK
 https://docs.venafi.com/Docs/19.2SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-POST-Certificates-Associate.php?tocpath=REST%20API%20reference%7CCertificates%20programming%20interface%7C_____6

--- a/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
+++ b/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
@@ -4,7 +4,7 @@ Add certificate association
 
 .DESCRIPTION
 Associates one or more Application objects to an existing certificate.
-Optionally, you can provision the certificate once the association is complete.
+Optionally, you can push the certificate once the association is complete.
 
 .PARAMETER InputObject
 TppObject which represents a certificate
@@ -15,9 +15,9 @@ Path to the certificate.  Required if InputObject not provided.
 .PARAMETER ApplicationPath
 List of application object paths to associate
 
-.PARAMETER ProvisionCertificate
-Provision the certificate after associating it to the Application objects.
-This will only be successful if the certificate management type is Provisioning and is not disabled, in error, or the provisioning is already in process.
+.PARAMETER PushCertificate
+Push the certificate after associating it to the Application objects.
+This will only be successful if the certificate management type is Provisioning and is not disabled, in error, or a push is already in process.
 
 .PARAMETER TppSession
 Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
@@ -33,8 +33,8 @@ Add-TppCertificateAssocation -CertificatePath '\ved\policy\my cert' -Application
 Add a single application object association
 
 .EXAMPLE
-Add-TppCertificateAssocation -Path '\ved\policy\my cert' -ApplicationPath '\ved\policy\my capi' -ProvisionCertificate
-Add the association and provision the certificate
+Add-TppCertificateAssocation -Path '\ved\policy\my cert' -ApplicationPath '\ved\policy\my capi' -PushCertificate
+Add the association and push the certificate
 
 .LINK
 http://venafitppps.readthedocs.io/en/latest/functions/Add-TppCertificateAssociation/
@@ -82,7 +82,8 @@ function Add-TppCertificateAssociation {
         [String[]] $ApplicationPath,
 
         [Parameter()]
-        [switch] $ProvisionCertificate,
+        [Alias('ProvisionCertificate')]
+        [switch] $PushCertificate,
 
         [Parameter()]
         [TppSession] $TppSession = $Script:TppSession
@@ -101,7 +102,7 @@ function Add-TppCertificateAssociation {
             }
         }
 
-        if ( $PSBoundParameters.ContainsKey('ProvisionCertificate') ) {
+        if ( $PSBoundParameters.ContainsKey('PushCertificate') ) {
             $params.Body.Add('PushToNew', 'true')
         }
     }
@@ -115,13 +116,8 @@ function Add-TppCertificateAssociation {
         $params.Body.CertificateDN = $CertificatePath
         $params.Body.ApplicationDN = @($ApplicationPath)
 
-        try {
-            if ( $PSCmdlet.ShouldProcess($CertificatePath, 'Add association') ) {
-                $null = Invoke-TppRestMethod @params
-            }
-        } catch {
-            $myError = $_.ToString() | ConvertFrom-Json
-            Write-Error ($myError.Error)
+        if ( $PSCmdlet.ShouldProcess($CertificatePath, 'Add association') ) {
+            $null = Invoke-TppRestMethod @params
         }
     }
 }

--- a/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
@@ -177,7 +177,7 @@ Renew all certificates expiring before a certain date
 http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCertificate/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCertificate.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____4

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
@@ -29,7 +29,7 @@ Find all environments that match the name Development
 http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignEnvironment/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1
 
 #>
 function Find-TppCodeSignEnvironment {

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
@@ -29,7 +29,7 @@ Find all projects that match the name CSTest
 http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignProject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8

--- a/VenafiTppPS/Code/Public/Find-TppCodeSignTemplate.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppCodeSignTemplate.ps1
@@ -29,7 +29,7 @@ Find all projects that match the name CSTest
 http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignProject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8

--- a/VenafiTppPS/Code/Public/Find-TppIdentity.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppIdentity.ps1
@@ -50,7 +50,7 @@ Find all identity types with the name greg and brownstein
 http://venafitppps.readthedocs.io/en/latest/functions/Find-TppIdentity/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppIdentity.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppIdentity.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Browse.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____5

--- a/VenafiTppPS/Code/Public/Find-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/Find-TppObject.ps1
@@ -72,7 +72,7 @@ Find all objects where the specific attribute matches the pattern
 http://venafitppps.readthedocs.io/en/latest/functions/Find-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppObject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-find.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____17

--- a/VenafiTppPS/Code/Public/Get-TppAttribute.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppAttribute.ps1
@@ -47,7 +47,7 @@ Retrieve all the value for attribute driver name from certificate myapp.company.
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppAttribute/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppAttribute.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppAttribute.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-read.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____27

--- a/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1
@@ -46,7 +46,7 @@ Get detailed certificate info via pipeline
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCertificateDetail/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.3SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates-guid.php?tocpath=Web%20SDK%20reference%7CCertificates%20programming%20interface%7C_____10

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1
@@ -30,7 +30,7 @@ Get settings
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignConfig/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-GET-Codesign-GetGlobalConfiguration.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CGlobalConfiguration%7C_____1

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
@@ -55,7 +55,7 @@ Get a environment after searching using Find-TppCodeSignEnvironment
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignEnvironment/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____9

--- a/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
@@ -43,7 +43,7 @@ Get a project after searching using Find-TppCodeSignProject
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignProject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10

--- a/VenafiTppPS/Code/Public/Get-TppIdentity.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppIdentity.ps1
@@ -37,7 +37,7 @@ Get identity details for user in the current session
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppIdentity/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentity.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentity.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15

--- a/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1
@@ -34,7 +34,7 @@ Get specific attribute for user
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppIdentityAttribute/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15

--- a/VenafiTppPS/Code/Public/Get-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppObject.ps1
@@ -34,7 +34,7 @@ Get an object by guid
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppObject.ps1
 
 #>
 function Get-TppObject {

--- a/VenafiTppPS/Code/Public/Get-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppObject.ps1
@@ -76,7 +76,7 @@ function Get-TppObject {
         }
 
         foreach ($thisInputObject in $inputObject) {
-            [TppObject]::new($thisInputObject)
+            [TppObject]::new($thisInputObject, $TppSession)
         }
     }
 }

--- a/VenafiTppPS/Code/Public/Get-TppPermission.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppPermission.ps1
@@ -171,7 +171,7 @@ function Get-TppPermission {
                 }
 
                 Default {
-                    $thisTppObject = [TppObject]::new($thisInputObject)
+                    $thisTppObject = [TppObject]::new($thisInputObject, $TppSession)
                 }
             }
 

--- a/VenafiTppPS/Code/Public/Get-TppPermission.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppPermission.ps1
@@ -67,10 +67,10 @@ Find assigned permissions for a specific user across all objects
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppPermission/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppPermission.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppPermission.ps1
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Permissions-object-guid.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____3

--- a/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1
@@ -22,7 +22,7 @@ Get the status
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppSystemStatus/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-SystemStatus.php?tocpath=Web%20SDK%7CSystemStatus%20programming%20interface%7C_____3

--- a/VenafiTppPS/Code/Public/Get-TppVersion.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppVersion.ps1
@@ -22,7 +22,7 @@ Get the version
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppVersion/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppVersion.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppVersion.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-SystemStatusVersion.php?tocpath=Web%20SDK%7CSystemStatus%20programming%20interface%7C_____9

--- a/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1
+++ b/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1
@@ -46,7 +46,7 @@ Get ticket details for multiple certificates
 http://venafitppps.readthedocs.io/en/latest/functions/Get-TppWorkflowTicket/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Workflow-ticket-enumerate.php?tocpath=Web%20SDK%7CWorkflow%20Ticket%20programming%20interface%7C_____7

--- a/VenafiTppPS/Code/Public/Invoke-TppCertificatePush.ps1
+++ b/VenafiTppPS/Code/Public/Invoke-TppCertificatePush.ps1
@@ -38,7 +38,7 @@ Push certificate to all associated applications
 http://venafitppps.readthedocs.io/en/latest/functions/Invoke-TppCertificatePush/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Invoke-TppCertificatePush.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Invoke-TppCertificatePush.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Push.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____15

--- a/VenafiTppPS/Code/Public/Invoke-TppCertificatePush.ps1
+++ b/VenafiTppPS/Code/Public/Invoke-TppCertificatePush.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+Push a certificate to an application
+
+.DESCRIPTION
+Push a certificate to one or more applications, or all associated
+This will only be successful if the certificate management type is Provisioning and is not disabled, in error, or a push is already in process.
+
+.PARAMETER CertificatePath
+Path to the certificate.
+
+.PARAMETER ApplicationPath
+List of application object paths to push to.
+If not provided, all associated applications will be pushed.
+
+.PARAMETER TppSession
+Session object created from New-TppSession method.  The value defaults to the script session object $TppSession.
+
+.INPUTS
+Path
+
+.OUTPUTS
+None
+
+.EXAMPLE
+$cert | Invoke-TppCertificatePush
+Push certificate to all associated applications, certificate object piped
+
+.EXAMPLE
+Invoke-TppCertificatePush -CertificatePath '\ved\policy\my cert' -ApplicationPath '\ved\policy\my capi'
+Push to a specific application associated with a certificate
+
+.EXAMPLE
+Invoke-TppCertificatePush -Path '\ved\policy\my cert'
+Push certificate to all associated applications
+
+.LINK
+http://venafitppps.readthedocs.io/en/latest/functions/Invoke-TppCertificatePush/
+
+.LINK
+https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Invoke-TppCertificatePush.ps1
+
+.LINK
+https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Push.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____15
+
+#>
+function Invoke-TppCertificatePush {
+
+    [CmdletBinding()]
+    param (
+
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {
+                if ( $_ | Test-TppDnPath ) {
+                    $true
+                } else {
+                    throw "'$_' is not a valid DN path"
+                }
+            })]
+        [Alias('DN', 'CertificateDN')]
+        [String] $CertificatePath,
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {
+                if ( $_ | Test-TppDnPath ) {
+                    $true
+                } else {
+                    throw "'$_' is not a valid DN path"
+                }
+            })]
+        [String[]] $ApplicationPath,
+
+        [Parameter()]
+        [TppSession] $TppSession = $Script:TppSession
+    )
+
+    begin {
+        $TppSession.Validate()
+
+        $params = @{
+            TppSession = $TppSession
+            Method     = 'Post'
+            UriLeaf    = 'Certificates/Push'
+            Body       = @{
+                CertificateDN = ''
+            }
+        }
+
+        if ( $PSBoundParameters.ContainsKey('ApplicationPath') ) {
+            $params.Body.ApplicationDN = @($ApplicationPath)
+        } else {
+            $params.Body.PushToAll = 'true'
+        }
+
+    }
+
+    process {
+        $params.Body.CertificateDN = $CertificatePath
+        $null = Invoke-TppRestMethod @params
+    }
+}

--- a/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1
+++ b/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1
@@ -34,7 +34,7 @@ Invoke-TppCertificateRenewal -Path '\VED\Policy\My folder\app.mycompany.com'
 http://venafitppps.readthedocs.io/en/latest/functions/Invoke-TppCertificateRenewal/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-renew.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____16

--- a/VenafiTppPS/Code/Public/Move-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/Move-TppObject.ps1
@@ -30,7 +30,7 @@ http://venafitppps.readthedocs.io/en/latest/functions/Move-TppObject/
 http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Move-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Move-TppObject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-renameobject.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____35

--- a/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
+++ b/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
@@ -84,10 +84,10 @@ Create a new application and return a TppObject for the newly created app
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppCapiApplication/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1
 
 .LINK
 http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCertificate/

--- a/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
+++ b/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
@@ -331,4 +331,6 @@ function New-TppCapiApplication {
 
         }
     }
+
+    end {}
 }

--- a/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
+++ b/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 Create a new CAPI application
 

--- a/VenafiTppPS/Code/Public/New-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/New-TppCertificate.ps1
@@ -63,7 +63,7 @@ Create certificate including subject alternate names
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppCertificate/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCertificate.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCertificate.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7CPOST%20Certificates%252FRequest%7C_____0

--- a/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
@@ -39,7 +39,7 @@ Create a new code sign project
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppCodeSignProject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-CreateProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____5

--- a/VenafiTppPS/Code/Public/New-TppDevice.ps1
+++ b/VenafiTppPS/Code/Public/New-TppDevice.ps1
@@ -18,8 +18,8 @@ Device description
 .PARAMETER CredentialPath
 Path to the credential which has permissions to update the device
 
-.PARAMETER IpAddress
-IP Address of the device
+.PARAMETER Hostname
+Hostname or IP Address of the device
 
 .PARAMETER PassThru
 Return a TppObject representing the newly created policy.
@@ -38,7 +38,7 @@ $newPolicy = New-TppDevice -Path '\VED\Policy\MyFolder\device' -PassThru
 Create device with full path to device and returning the object created
 
 .EXAMPLE
-$policyPath | New-TppDevice -DeviceName 'myDevice' -IpAddress 1.2.3.4
+$policyPath | New-TppDevice -DeviceName 'myDevice' -Hostname 1.2.3.4
 Pipe policy path and provide device details
 
 .LINK
@@ -93,7 +93,8 @@ function New-TppDevice {
         [string] $CredentialPath,
 
         [Parameter()]
-        [ipaddress] $IpAddress,
+        [Alias('IpAddress')]
+        [string] $Hostname,
 
         [Parameter()]
         [switch] $PassThru,
@@ -122,8 +123,8 @@ function New-TppDevice {
             $params.Attribute['Credential'] = $CredentialPath
         }
 
-        if ( $PSBoundParameters.ContainsKey('IpAddress') ) {
-            $params.Attribute['Host'] = $IpAddress.ToString()
+        if ( $PSBoundParameters.ContainsKey('Hostname') ) {
+            $params.Attribute['Host'] = $Hostname
         }
 
         # if no attributes were provided, we need to pull out the attribute key

--- a/VenafiTppPS/Code/Public/New-TppDevice.ps1
+++ b/VenafiTppPS/Code/Public/New-TppDevice.ps1
@@ -45,13 +45,13 @@ Pipe policy path and provide device details
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppDevice/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppDevice.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppDevice.ps1
 
 .LINK
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1
 
 #>
 function New-TppDevice {

--- a/VenafiTppPS/Code/Public/New-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/New-TppObject.ps1
@@ -49,10 +49,10 @@ TppObject, if PassThru provided
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-create.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____9

--- a/VenafiTppPS/Code/Public/New-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/New-TppObject.ps1
@@ -16,7 +16,7 @@ See https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/SchemaReferen
 Hashtable with initial values for the new object.
 These will be specific to the object class being created.
 
-.PARAMETER ProvisionCertificate
+.PARAMETER PushCertificate
 If creating an application object, you can optionally push the certificate once the creation is complete.
 Only available if a 'Certificate' key containing the certificate path is provided for Attribute.
 Please note, this feature was added in v18.3.
@@ -86,7 +86,8 @@ function New-TppObject {
         [Hashtable] $Attribute,
 
         [Parameter()]
-        [switch] $ProvisionCertificate,
+        [Alias('ProvisionCertificate')]
+        [switch] $PushCertificate,
 
         [Parameter()]
         [switch] $PassThru,
@@ -107,8 +108,8 @@ function New-TppObject {
     #     throw ("The parent folder, {0}, of your new object does not exist" -f (Split-Path -Path $Path -Parent))
     # }
 
-    if ( $PSBoundParameters.ContainsKey('ProvisionCertificate') -and (-not $Attribute.Certificate) ) {
-        Write-Warning 'A ''Certificate'' key containing the certificate path must be provided for Attribute when using ProvisionCertificate, eg. -Attribute @{''Certificate''=''\Ved\Policy\mycert.com''}.  Certificate provisioning will not take place.'
+    if ( $PushCertificate.IsPresent -and (-not $Attribute.Certificate) ) {
+        Write-Warning 'A ''Certificate'' key containing the certificate path must be provided for Attribute when using PushCertificate, eg. -Attribute @{''Certificate''=''\Ved\Policy\mycert.com''}.  Certificate provisioning will not take place.'
     }
 
     $params = @{
@@ -144,8 +145,8 @@ function New-TppObject {
                 CertificatePath = $Attribute.Certificate
                 ApplicationPath = $response.Object.DN
             }
-            if ( $PSBoundParameters.ContainsKey('ProvisionCertificate') ) {
-                $associateParams.Add('ProvisionCertificate', $true)
+            if ( $PushCertificate.IsPresent ) {
+                $associateParams.Add('PushCertificate', $true)
             }
 
             Add-TppCertificateAssociation @associateParams -TppSession $TppSession

--- a/VenafiTppPS/Code/Public/New-TppPolicy.ps1
+++ b/VenafiTppPS/Code/Public/New-TppPolicy.ps1
@@ -35,13 +35,13 @@ Create policy with description
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppPolicy/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppPolicy.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppPolicy.ps1
 
 .LINK
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1
 
 #>
 function New-TppPolicy {

--- a/VenafiTppPS/Code/Public/New-TppSession.ps1
+++ b/VenafiTppPS/Code/Public/New-TppSession.ps1
@@ -72,7 +72,7 @@ Create session and return the session object instead of setting to script scope 
 http://venafitppps.readthedocs.io/en/latest/functions/New-TppSession/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppSession.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppSession.ps1
 
 .LINK
 https://docs.venafi.com/Docs/19.4/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-POST-Authorize.php?tocpath=Topics%20by%20Guide%7CDeveloper%27s%20Guide%7CWeb%20SDK%20reference%7CAuthentication%20programming%20interfaces%7C_____1

--- a/VenafiTppPS/Code/Public/New-TppSession.ps1
+++ b/VenafiTppPS/Code/Public/New-TppSession.ps1
@@ -105,11 +105,11 @@ function New-TppSession {
                 if ( $_ -match '^(https?:\/\/)?(((?!-))(xn--|_{1,1})?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9\-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$' ) {
                     $true
                 } else {
-                    throw 'Please enter a valid server, https://venafi.company.com or venafi.company.com'
+                    throw "'$_' is not a valid server url, it should look like https://venafi.company.com or venafi.company.com"
                 }
             }
         )]
-        [Alias('ServerUrl')]
+        [Alias('ServerUrl', 'Url')]
         [string] $Server,
 
         [Parameter(Mandatory, ParameterSetName = 'KeyCredential')]

--- a/VenafiTppPS/Code/Public/Read-TppLog.ps1
+++ b/VenafiTppPS/Code/Public/Read-TppLog.ps1
@@ -71,7 +71,7 @@ Find all events for a specific object
 http://venafitppps.readthedocs.io/en/latest/functions/Read-TppLog/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Read-TppLog.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Read-TppLog.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Log.php?tocpath=Web%20SDK%7CLog%20programming%20interface%7C_____2

--- a/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1
@@ -42,7 +42,7 @@ Remove a certificate and automatically remove all associations
 http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCertificate/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-DELETE-Certificates-Guid.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____9

--- a/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1
+++ b/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1
@@ -47,7 +47,7 @@ Remove all certificate associations
 http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCertificateAssociation/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Dissociate.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____8

--- a/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1
+++ b/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1
@@ -29,7 +29,7 @@ Remove 1 or more environments.  Get environments with Find-TppCodeSignEnvironmen
 http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignEnvironment/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____6

--- a/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1
+++ b/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1
@@ -29,7 +29,7 @@ Remove 1 or more projects.  Get projects with Find-TppCodeSignProject
 http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignProject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____7

--- a/VenafiTppPS/Code/Public/Remove-TppPermission.ps1
+++ b/VenafiTppPS/Code/Public/Remove-TppPermission.ps1
@@ -33,7 +33,7 @@ Remove all permissions for a specific user
 http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppPermission/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppPermission.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppPermission.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-DELETE-Permissions-object-guid-principal.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____6

--- a/VenafiTppPS/Code/Public/Rename-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/Rename-TppObject.ps1
@@ -30,7 +30,7 @@ http://venafitppps.readthedocs.io/en/latest/functions/Rename-TppObject/
 http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Rename-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Rename-TppObject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-renameobject.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____35

--- a/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1
+++ b/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1
@@ -56,7 +56,7 @@ Revoke the certificate with a reason of the CA being compromised and wait for it
 http://venafitppps.readthedocs.io/en/latest/functions/Revoke-TppCertificate/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-revoke.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____24

--- a/VenafiTppPS/Code/Public/Revoke-TppToken.ps1
+++ b/VenafiTppPS/Code/Public/Revoke-TppToken.ps1
@@ -36,7 +36,7 @@ Revoke a token obtained from TPP, not necessarily via VenafiTppPS
 http://venafitppps.readthedocs.io/en/latest/functions/Revoke-TppToken/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Revoke-TppToken.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Revoke-TppToken.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.1SDK/TopNav/Content/SDK/AuthSDK/r-SDKa-GET-Revoke-Token.php?tocpath=Auth%20SDK%20reference%20for%20token%20management%7C_____13

--- a/VenafiTppPS/Code/Public/Set-TppAttribute.ps1
+++ b/VenafiTppPS/Code/Public/Set-TppAttribute.ps1
@@ -41,7 +41,7 @@ Set value on a certificate by overwriting any existing values
 http://venafitppps.readthedocs.io/en/latest/functions/Set-TppAttribute/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppAttribute.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppAttribute.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-addvalue.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____4

--- a/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
+++ b/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
@@ -28,7 +28,7 @@ Update project status
 http://venafitppps.readthedocs.io/en/latest/functions/Set-TppCodeSignProjectStatus/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-UpdateProjectStatus.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____14

--- a/VenafiTppPS/Code/Public/Set-TppPermission.ps1
+++ b/VenafiTppPS/Code/Public/Set-TppPermission.ps1
@@ -49,7 +49,7 @@ Reset permissions for a specific user/group for all objects.  Note the use of -F
 http://venafitppps.readthedocs.io/en/latest/functions/Set-TppPermission/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppPermission.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppPermission.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Permissions-object-guid-principal.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____8

--- a/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1
+++ b/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1
@@ -44,7 +44,7 @@ Approve all tickets for a certificate after a certain date with an explanation
 http://venafitppps.readthedocs.io/en/latest/functions/Set-TppWorkflowTicketStatus/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Workflow-ticket-updatestatus.php?tocpath=Web%20SDK%7CWorkflow%20Ticket%20programming%20interface%7C_____10

--- a/VenafiTppPS/Code/Public/Test-TppIdentity.ps1
+++ b/VenafiTppPS/Code/Public/Test-TppIdentity.ps1
@@ -34,7 +34,7 @@ Retrieve existence for only one identity, returns boolean
 http://venafitppps.readthedocs.io/en/latest/functions/Test-TppIdentity/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Test-TppIdentity.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Test-TppIdentity.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15

--- a/VenafiTppPS/Code/Public/Test-TppObject.ps1
+++ b/VenafiTppPS/Code/Public/Test-TppObject.ps1
@@ -41,7 +41,7 @@ Retrieve existence for only one object
 http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Test-TppObject.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Test-TppObject.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-isvalid.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____25

--- a/VenafiTppPS/Code/Public/Write-TppLog.ps1
+++ b/VenafiTppPS/Code/Public/Write-TppLog.ps1
@@ -56,7 +56,7 @@ Log an event to a custom group
 http://venafitppps.readthedocs.io/en/latest/functions/Write-TppLog/
 
 .LINK
-https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Write-TppLog.ps1
+https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Write-TppLog.ps1
 
 .LINK
 https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Log.php?tocpath=Web%20SDK%7CLog%20programming%20interface%7C_____3

--- a/VenafiTppPS/Code/VenafiTppPS.psd1
+++ b/VenafiTppPS/Code/VenafiTppPS.psd1
@@ -117,16 +117,16 @@ PrivateData = @{
         Tags = 'Venafi','TPP','TrustProtectionPlatform','API'
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/gdbarron/VenafiTppPS/blob/master/LICENSE'
+        LicenseUri = 'https://github.com/gdbarron/VenafiTppPS/blob/main/LICENSE'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/gdbarron/VenafiTppPS'
 
         # A URL to an icon representing this module.
-        IconUri = 'https://raw.githubusercontent.com/gdbarron/VenafiTppPS/master/images/Ven_circleV_logo.png'
+        IconUri = 'https://raw.githubusercontent.com/gdbarron/VenafiTppPS/main/images/Ven_circleV_logo.png'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/gdbarron/VenafiTppPS/blob/master/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/gdbarron/VenafiTppPS/blob/main/CHANGELOG.md'
 
         # Prerelease string of this module
         # Prerelease = ''

--- a/VenafiTppPS/Code/VenafiTppPS.psd1
+++ b/VenafiTppPS/Code/VenafiTppPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VenafiTppPS.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.0'
+ModuleVersion = '2.2.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -69,26 +69,26 @@ PowerShellVersion = '5.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Add-TppCertificateAssociation', 'ConvertTo-TppGuid', 
-               'ConvertTo-TppPath', 'Find-TppCertificate', 
-               'Find-TppCodeSignEnvironment', 'Find-TppCodeSignProject', 
-               'Find-TppCodeSignTemplate', 'Find-TppIdentity', 'Find-TppObject', 
-               'Get-TppAttribute', 'Get-TppCertificate', 'Get-TppCertificateDetail', 
-               'Get-TppCodeSignConfig', 'Get-TppCodeSignEnvironment', 
-               'Get-TppCodeSignProject', 'Get-TppCustomField', 'Get-TppIdentity', 
-               'Get-TppIdentityAttribute', 'Get-TppObject', 'Get-TppPermission', 
-               'Get-TppSystemStatus', 'Get-TppVersion', 'Get-TppWorkflowTicket', 
-               'Import-TppCertificate', 'Invoke-TppCertificateRenewal', 
-               'Invoke-TppRestMethod', 'Move-TppObject', 'New-TppCapiApplication', 
-               'New-TppCertificate', 'New-TppCodeSignProject', 'New-TppDevice', 
-               'New-TppObject', 'New-TppPolicy', 'New-TppSession', 'New-TppToken', 
-               'Read-TppLog', 'Remove-TppCertificate', 
-               'Remove-TppCertificateAssociation', 'Remove-TppCodeSignEnvironment', 
-               'Remove-TppCodeSignProject', 'Remove-TppPermission', 
-               'Rename-TppObject', 'Revoke-TppCertificate', 'Revoke-TppToken', 
-               'Set-TppAttribute', 'Set-TppCodeSignProjectStatus', 
-               'Set-TppPermission', 'Set-TppWorkflowTicketStatus', 
-               'Test-TppIdentity', 'Test-TppObject', 'Write-TppLog'
+FunctionsToExport = 'Add-TppCertificateAssociation', 'ConvertTo-TppGuid',
+               'ConvertTo-TppPath', 'Find-TppCertificate',
+               'Find-TppCodeSignEnvironment', 'Find-TppCodeSignProject',
+               'Find-TppCodeSignTemplate', 'Find-TppIdentity', 'Find-TppObject',
+               'Get-TppAttribute', 'Get-TppCertificate', 'Get-TppCertificateDetail',
+               'Get-TppCodeSignConfig', 'Get-TppCodeSignEnvironment',
+               'Get-TppCodeSignProject', 'Get-TppCustomField', 'Get-TppIdentity',
+               'Get-TppIdentityAttribute', 'Get-TppObject', 'Get-TppPermission',
+               'Get-TppSystemStatus', 'Get-TppVersion', 'Get-TppWorkflowTicket',
+               'Import-TppCertificate', 'Invoke-TppCertificateRenewal',
+               'Invoke-TppRestMethod', 'Move-TppObject', 'New-TppCapiApplication',
+               'New-TppCertificate', 'New-TppCodeSignProject', 'New-TppDevice',
+               'New-TppObject', 'New-TppPolicy', 'New-TppSession', 'New-TppToken',
+               'Read-TppLog', 'Remove-TppCertificate',
+               'Remove-TppCertificateAssociation', 'Remove-TppCodeSignEnvironment',
+               'Remove-TppCodeSignProject', 'Remove-TppPermission',
+               'Rename-TppObject', 'Revoke-TppCertificate', 'Revoke-TppToken',
+               'Set-TppAttribute', 'Set-TppCodeSignProjectStatus',
+               'Set-TppPermission', 'Set-TppWorkflowTicketStatus',
+               'Test-TppIdentity', 'Test-TppObject', 'Write-TppLog', 'Invoke-TppCertificatePush'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/build/deploy.PSDeploy.ps1
+++ b/build/deploy.PSDeploy.ps1
@@ -21,7 +21,7 @@
 if (
     $env:BHModulePath -and
     $env:BHBuildSystem -ne 'Unknown' -and
-    $env:BHBranchName -eq "master" -and
+    $env:BHBranchName -eq "main" -and
     $env:BHCommitMessage -match '!deploy'
 ) {
     Deploy Module {
@@ -36,7 +36,7 @@ if (
 } else {
     "Skipping deployment: To deploy, ensure that...`n" +
     "`t* You are in a known build system (Current: $ENV:BHBuildSystem)`n" +
-    "`t* You are committing to the master branch (Current: $ENV:BHBranchName) `n" +
+    "`t* You are committing to the main branch (Current: $ENV:BHBranchName) `n" +
     "`t* Your commit message includes !deploy (Current: $ENV:BHCommitMessage)" |
         Write-Host
 }

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,1 +1,1 @@
-https://github.com/gdbarron/VenafiTppPS/blob/master/CHANGELOG.md
+https://github.com/gdbarron/VenafiTppPS/blob/main/CHANGELOG.md

--- a/docs/functions/Add-TppCertificateAssociation.md
+++ b/docs/functions/Add-TppCertificateAssociation.md
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 ```
 
 ### -CertificatePath
-Path to the certificate. 
+Path to the certificate.
 Required if InputObject not provided.
 
 ```yaml
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -166,7 +166,7 @@ You must have:
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Add-TppCertificateAssociation/](http://venafitppps.readthedocs.io/en/latest/functions/Add-TppCertificateAssociation/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1)
 
 [https://docs.venafi.com/Docs/19.2SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-POST-Certificates-Associate.php?tocpath=REST%20API%20reference%7CCertificates%20programming%20interface%7C_____6](https://docs.venafi.com/Docs/19.2SDK/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-POST-Certificates-Associate.php?tocpath=REST%20API%20reference%7CCertificates%20programming%20interface%7C_____6)
 

--- a/docs/functions/Find-TppCertificate.md
+++ b/docs/functions/Find-TppCertificate.md
@@ -189,7 +189,7 @@ Accept wildcard characters: False
 ```
 
 ### -Limit
-Limit how many items are returned. 
+Limit how many items are returned.
 Default is 0 for no limit.
 It is definitely recommended to filter on another property when searching with no limit.
 
@@ -767,7 +767,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -797,7 +797,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCertificate/](http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCertificate/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCertificate.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCertificate.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____4](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____4)
 

--- a/docs/functions/Find-TppCodeSignEnvironment.md
+++ b/docs/functions/Find-TppCodeSignEnvironment.md
@@ -16,7 +16,7 @@ Find-TppCodeSignEnvironment -Name <String> [-TppSession <TppSession>] [<CommonPa
 ```
 
 ## DESCRIPTION
-Search for specific code sign environments that match a name you provide or get all. 
+Search for specific code sign environments that match a name you provide or get all.
 This will search across projects.
 
 ## EXAMPLES
@@ -53,7 +53,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -83,5 +83,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignEnvironment/](http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignEnvironment/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignEnvironment.ps1)
 

--- a/docs/functions/Find-TppCodeSignProject.md
+++ b/docs/functions/Find-TppCodeSignProject.md
@@ -52,7 +52,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignProject/](http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignProject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1)
 
 [https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8](https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8)
 

--- a/docs/functions/Find-TppCodeSignTemplate.md
+++ b/docs/functions/Find-TppCodeSignTemplate.md
@@ -52,7 +52,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -82,7 +82,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignProject/](http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCodeSignProject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppCodeSignProject.ps1)
 
 [https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8](https://docs.venafi.com/Docs/20.3/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-EnumerateProjects.php?tocpath=CodeSign%20Protect%20SDK%20reference%7CProjects%20and%20environments%7C_____8)
 

--- a/docs/functions/Find-TppIdentity.md
+++ b/docs/functions/Find-TppIdentity.md
@@ -114,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -Me
-Returns the identity of the authenticated user and all associated identities. 
+Returns the identity of the authenticated user and all associated identities.
 Will be deprecated in a future release, use Get-TppIdentity -Me instead.
 
 ```yaml
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -163,7 +163,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Find-TppIdentity/](http://venafitppps.readthedocs.io/en/latest/functions/Find-TppIdentity/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppIdentity.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppIdentity.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppIdentity.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppIdentity.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Browse.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____5](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Browse.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____5)
 

--- a/docs/functions/Find-TppObject.md
+++ b/docs/functions/Find-TppObject.md
@@ -83,7 +83,7 @@ Get all objects of the type iis6 or capi
 Find-TppObject -Pattern 'test*'
 ```
 
-Find objects with the specific name. 
+Find objects with the specific name.
 All objects will be searched.
 
 ### EXAMPLE 8
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 ```
 
 ### -Attribute
-A list of attribute names to limit the search against. 
+A list of attribute names to limit the search against.
 Only valid when searching by pattern.
 
 ```yaml
@@ -194,7 +194,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -224,7 +224,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Find-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/Find-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Find-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Find-TppObject.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-find.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____17](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-find.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____17)
 

--- a/docs/functions/Get-TppAttribute.md
+++ b/docs/functions/Get-TppAttribute.md
@@ -40,7 +40,7 @@ Get-TppAttribute -Guid <Guid[]> -Attribute <String[]> [-Effective] [-TppSession 
 ```
 
 ## DESCRIPTION
-Retrieves object attributes. 
+Retrieves object attributes.
 You can either retrieve all attributes or individual ones.
 By default, the attributes returned are not the effective policy, but that can be requested with the
 EffectivePolicy switch.
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Path to the object to retrieve configuration attributes. 
+Path to the object to retrieve configuration attributes.
 Just providing DN will return all attributes.
 
 ```yaml
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -Guid
-Object Guid. 
+Object Guid.
 Just providing Guid will return all attributes.
 
 ```yaml
@@ -160,7 +160,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -190,7 +190,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppAttribute/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppAttribute/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppAttribute.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppAttribute.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-read.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____27](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-read.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____27)
 

--- a/docs/functions/Get-TppCertificateDetail.md
+++ b/docs/functions/Get-TppCertificateDetail.md
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCertificateDetail/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCertificateDetail/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCertificateDetail.ps1)
 
 [https://docs.venafi.com/Docs/20.3SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates-guid.php?tocpath=Web%20SDK%20reference%7CCertificates%20programming%20interface%7C_____10](https://docs.venafi.com/Docs/20.3SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Certificates-guid.php?tocpath=Web%20SDK%20reference%7CCertificates%20programming%20interface%7C_____10)
 

--- a/docs/functions/Get-TppCodeSignConfig.md
+++ b/docs/functions/Get-TppCodeSignConfig.md
@@ -10,7 +10,7 @@ Get-TppCodeSignConfig [[-TppSession] <TppSession>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Get CodeSign Protect project settings. 
+Get CodeSign Protect project settings.
 Must have token with scope codesign:manage.
 
 ## EXAMPLES
@@ -25,7 +25,7 @@ Get settings
 ## PARAMETERS
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -63,7 +63,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignConfig/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignConfig/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignConfig.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-GET-Codesign-GetGlobalConfiguration.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CGlobalConfiguration%7C_____1](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-GET-Codesign-GetGlobalConfiguration.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CGlobalConfiguration%7C_____1)
 

--- a/docs/functions/Get-TppCodeSignEnvironment.md
+++ b/docs/functions/Get-TppCodeSignEnvironment.md
@@ -46,7 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignEnvironment/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignEnvironment/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignEnvironment.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____9](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____9)
 

--- a/docs/functions/Get-TppCodeSignProject.md
+++ b/docs/functions/Get-TppCodeSignProject.md
@@ -46,7 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -90,7 +90,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignProject/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppCodeSignProject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppCodeSignProject.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-GetProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____10)
 

--- a/docs/functions/Get-TppIdentity.md
+++ b/docs/functions/Get-TppIdentity.md
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppIdentity/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppIdentity/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentity.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentity.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentity.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentity.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15)
 

--- a/docs/functions/Get-TppIdentityAttribute.md
+++ b/docs/functions/Get-TppIdentityAttribute.md
@@ -32,7 +32,7 @@ Get specific attribute for user
 ## PARAMETERS
 
 ### -ID
-The id that represents the user or group. 
+The id that represents the user or group.
 Use Find-TppIdentity to get the id.
 
 ```yaml
@@ -63,7 +63,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -93,7 +93,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppIdentityAttribute/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppIdentityAttribute/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15)
 

--- a/docs/functions/Get-TppObject.md
+++ b/docs/functions/Get-TppObject.md
@@ -16,7 +16,7 @@ Get-TppObject -Guid <Guid[]> [-TppSession <TppSession>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Return object information by either path or guid. 
+Return object information by either path or guid.
 This will return a TppObject which can be used with many other functions.
 
 ## EXAMPLES
@@ -68,7 +68,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -98,5 +98,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppObject.ps1)
 

--- a/docs/functions/Get-TppPermission.md
+++ b/docs/functions/Get-TppPermission.md
@@ -148,7 +148,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -189,9 +189,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppPermission/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppPermission/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppPermission.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppPermission.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppPermission.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppPermission.ps1)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppIdentityAttribute.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Permissions-object-guid.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____3](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Permissions-object-guid.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____3)
 

--- a/docs/functions/Get-TppSystemStatus.md
+++ b/docs/functions/Get-TppSystemStatus.md
@@ -24,7 +24,7 @@ Get the status
 ## PARAMETERS
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -54,7 +54,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppSystemStatus/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppSystemStatus/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppSystemStatus.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-SystemStatus.php?tocpath=Web%20SDK%7CSystemStatus%20programming%20interface%7C_____3](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-SystemStatus.php?tocpath=Web%20SDK%7CSystemStatus%20programming%20interface%7C_____3)
 

--- a/docs/functions/Get-TppVersion.md
+++ b/docs/functions/Get-TppVersion.md
@@ -24,7 +24,7 @@ Get the version
 ## PARAMETERS
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -54,7 +54,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppVersion/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppVersion/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppVersion.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppVersion.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppVersion.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppVersion.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-SystemStatusVersion.php?tocpath=Web%20SDK%7CSystemStatus%20programming%20interface%7C_____9](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-SystemStatusVersion.php?tocpath=Web%20SDK%7CSystemStatus%20programming%20interface%7C_____9)
 

--- a/docs/functions/Get-TppWorkflowTicket.md
+++ b/docs/functions/Get-TppWorkflowTicket.md
@@ -87,7 +87,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -128,7 +128,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Get-TppWorkflowTicket/](http://venafitppps.readthedocs.io/en/latest/functions/Get-TppWorkflowTicket/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Get-TppWorkflowTicket.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Workflow-ticket-enumerate.php?tocpath=Web%20SDK%7CWorkflow%20Ticket%20programming%20interface%7C_____7](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Workflow-ticket-enumerate.php?tocpath=Web%20SDK%7CWorkflow%20Ticket%20programming%20interface%7C_____7)
 

--- a/docs/functions/Invoke-TppCertificateRenewal.md
+++ b/docs/functions/Invoke-TppCertificateRenewal.md
@@ -66,7 +66,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -131,7 +131,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Invoke-TppCertificateRenewal/](http://venafitppps.readthedocs.io/en/latest/functions/Invoke-TppCertificateRenewal/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Invoke-TppCertificateRenewal.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-renew.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____16](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-renew.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____16)
 

--- a/docs/functions/Move-TppObject.md
+++ b/docs/functions/Move-TppObject.md
@@ -54,7 +54,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Move-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Move-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Move-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Move-TppObject.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-renameobject.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____35](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-renameobject.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____35)
 

--- a/docs/functions/New-TppCapiApplication.md
+++ b/docs/functions/New-TppCapiApplication.md
@@ -37,7 +37,7 @@ PS C:\> {{ Add example code here }}
 ## PARAMETERS
 
 ### -Path
-Full path, including name, to the application to be created. 
+Full path, including name, to the application to be created.
 The application must be created under a device.
 Alternatively, provide the path to the device and provide ApplicationName.
 
@@ -54,7 +54,7 @@ Accept wildcard characters: False
 ```
 
 ### -ApplicationName
-1 or more application names to create. 
+1 or more application names to create.
 Path must be a path to a device.
 
 ```yaml
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -Disable
-Set processing to disabled. 
+Set processing to disabled.
 It is enabled by default.
 
 ```yaml
@@ -236,7 +236,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionCertificate
-Push the certificate to the application. 
+Push the certificate to the application.
 CertificatePath must be provided.
 
 ```yaml
@@ -283,7 +283,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -344,9 +344,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppCapiApplication/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppCapiApplication/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCapiApplication.ps1)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1)
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCertificate/](http://venafitppps.readthedocs.io/en/latest/functions/Find-TppCertificate/)
 

--- a/docs/functions/New-TppCertificate.md
+++ b/docs/functions/New-TppCertificate.md
@@ -36,7 +36,7 @@ Create certificate by name
 New-TppCertificate -Path '\ved\policy\folder' -CommonName 'mycert.com' -CertificateAuthorityDN '\ved\policy\CA Templates\my template' -PassThru
 ```
 
-Create certificate using common name. 
+Create certificate using common name.
 Return the created object.
 
 ### EXAMPLE 3
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Name of the certifcate. 
+Name of the certifcate.
 If not provided, the name will be the same as the subject.
 
 ```yaml
@@ -81,7 +81,7 @@ Accept wildcard characters: False
 ```
 
 ### -CommonName
-Subject Common Name. 
+Subject Common Name.
 If Name isn't provided, CommonName will be used.
 
 ```yaml
@@ -197,7 +197,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -258,7 +258,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppCertificate/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppCertificate/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCertificate.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCertificate.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7CPOST%20Certificates%252FRequest%7C_____0](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7CPOST%20Certificates%252FRequest%7C_____0)
 

--- a/docs/functions/New-TppCodeSignProject.md
+++ b/docs/functions/New-TppCodeSignProject.md
@@ -39,7 +39,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -114,7 +114,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppCodeSignProject/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppCodeSignProject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppCodeSignProject.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-CreateProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____5](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-CreateProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____5)
 

--- a/docs/functions/New-TppDevice.md
+++ b/docs/functions/New-TppDevice.md
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -DeviceName
-Name of 1 or more devices to create. 
+Name of 1 or more devices to create.
 Path must be of type Policy to use this.
 
 ```yaml
@@ -125,7 +125,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -186,9 +186,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppDevice/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppDevice/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppDevice.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppDevice.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppDevice.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppDevice.ps1)
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1)
 

--- a/docs/functions/New-TppObject.md
+++ b/docs/functions/New-TppObject.md
@@ -118,7 +118,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -179,9 +179,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Add-TppCertificateAssociation.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-create.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____9](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-create.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____9)
 

--- a/docs/functions/New-TppPolicy.md
+++ b/docs/functions/New-TppPolicy.md
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -138,9 +138,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppPolicy/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppPolicy/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppPolicy.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppPolicy.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppPolicy.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppPolicy.ps1)
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppObject.ps1)
 

--- a/docs/functions/New-TppSession.md
+++ b/docs/functions/New-TppSession.md
@@ -119,7 +119,7 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Username and password used for key and token-based authentication. 
+Username and password used for key and token-based authentication.
 Not required for integrated authentication.
 
 ```yaml
@@ -305,7 +305,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/New-TppSession/](http://venafitppps.readthedocs.io/en/latest/functions/New-TppSession/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppSession.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/New-TppSession.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppSession.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/New-TppSession.ps1)
 
 [https://docs.venafi.com/Docs/19.4/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-POST-Authorize.php?tocpath=Topics%20by%20Guide%7CDeveloper%27s%20Guide%7CWeb%20SDK%20reference%7CAuthentication%20programming%20interfaces%7C_____1](https://docs.venafi.com/Docs/19.4/TopNav/Content/SDK/WebSDK/API_Reference/r-SDK-POST-Authorize.php?tocpath=Topics%20by%20Guide%7CDeveloper%27s%20Guide%7CWeb%20SDK%20reference%7CAuthentication%20programming%20interfaces%7C_____1)
 

--- a/docs/functions/Read-TppLog.md
+++ b/docs/functions/Read-TppLog.md
@@ -184,7 +184,7 @@ Accept wildcard characters: False
 ```
 
 ### -Limit
-Specify the number of items to retrieve, starting with most recent. 
+Specify the number of items to retrieve, starting with most recent.
 The default is 100 and there is no maximum.
 
 ```yaml
@@ -200,7 +200,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -245,7 +245,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Read-TppLog/](http://venafitppps.readthedocs.io/en/latest/functions/Read-TppLog/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Read-TppLog.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Read-TppLog.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Read-TppLog.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Read-TppLog.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Log.php?tocpath=Web%20SDK%7CLog%20programming%20interface%7C_____2](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-GET-Log.php?tocpath=Web%20SDK%7CLog%20programming%20interface%7C_____2)
 

--- a/docs/functions/Remove-TppCertificate.md
+++ b/docs/functions/Remove-TppCertificate.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -155,7 +155,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCertificate/](http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCertificate/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCertificate.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-DELETE-Certificates-Guid.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____9](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-DELETE-Certificates-Guid.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____9)
 

--- a/docs/functions/Remove-TppCertificateAssociation.md
+++ b/docs/functions/Remove-TppCertificateAssociation.md
@@ -136,7 +136,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -201,7 +201,7 @@ You must have:
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCertificateAssociation/](http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCertificateAssociation/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCertificateAssociation.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Dissociate.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____8](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Dissociate.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____8)
 

--- a/docs/functions/Remove-TppCodeSignEnvironment.md
+++ b/docs/functions/Remove-TppCodeSignEnvironment.md
@@ -28,7 +28,7 @@ Delete an environment
 $envObj | Remove-TppCodeSignEnvironment
 ```
 
-Remove 1 or more environments. 
+Remove 1 or more environments.
 Get environments with Find-TppCodeSignEnvironment
 
 ## PARAMETERS
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -110,7 +110,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignEnvironment/](http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignEnvironment/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCodeSignEnvironment.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____6](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteEnvironment.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____6)
 

--- a/docs/functions/Remove-TppCodeSignProject.md
+++ b/docs/functions/Remove-TppCodeSignProject.md
@@ -11,7 +11,7 @@ Remove-TppCodeSignProject [-Path] <String> [[-TppSession] <TppSession>] [-WhatIf
 ```
 
 ## DESCRIPTION
-Delete a code sign project. 
+Delete a code sign project.
 You must be a code sign admin or owner of the project.
 
 ## EXAMPLES
@@ -28,7 +28,7 @@ Delete a project
 $projectObj | Remove-TppCodeSignProject
 ```
 
-Remove 1 or more projects. 
+Remove 1 or more projects.
 Get projects with Find-TppCodeSignProject
 
 ## PARAMETERS
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -110,7 +110,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignProject/](http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppCodeSignProject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppCodeSignProject.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____7](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-DeleteProject.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____7)
 

--- a/docs/functions/Remove-TppPermission.md
+++ b/docs/functions/Remove-TppPermission.md
@@ -40,7 +40,7 @@ Remove all permissions for a specific user
 ## PARAMETERS
 
 ### -Path
-Full path to an object. 
+Full path to an object.
 You can also pipe in a TppObject
 
 ```yaml
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -147,7 +147,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppPermission/](http://venafitppps.readthedocs.io/en/latest/functions/Remove-TppPermission/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppPermission.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Remove-TppPermission.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppPermission.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Remove-TppPermission.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-DELETE-Permissions-object-guid-principal.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____6](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-DELETE-Permissions-object-guid-principal.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____6)
 

--- a/docs/functions/Rename-TppObject.md
+++ b/docs/functions/Rename-TppObject.md
@@ -54,7 +54,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Rename-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Rename-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Rename-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Rename-TppObject.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-renameobject.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____35](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-renameobject.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____35)
 

--- a/docs/functions/Revoke-TppCertificate.md
+++ b/docs/functions/Revoke-TppCertificate.md
@@ -138,7 +138,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -202,7 +202,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Revoke-TppCertificate/](http://venafitppps.readthedocs.io/en/latest/functions/Revoke-TppCertificate/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Revoke-TppCertificate.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-revoke.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____24](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-revoke.php?tocpath=Web%20SDK%7CCertificates%20programming%20interface%7C_____24)
 

--- a/docs/functions/Revoke-TppToken.md
+++ b/docs/functions/Revoke-TppToken.md
@@ -88,7 +88,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -149,7 +149,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Revoke-TppToken/](http://venafitppps.readthedocs.io/en/latest/functions/Revoke-TppToken/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Revoke-TppToken.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Revoke-TppToken.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Revoke-TppToken.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Revoke-TppToken.ps1)
 
 [https://docs.venafi.com/Docs/20.1SDK/TopNav/Content/SDK/AuthSDK/r-SDKa-GET-Revoke-Token.php?tocpath=Auth%20SDK%20reference%20for%20token%20management%7C_____13](https://docs.venafi.com/Docs/20.1SDK/TopNav/Content/SDK/AuthSDK/r-SDKa-GET-Revoke-Token.php?tocpath=Auth%20SDK%20reference%20for%20token%20management%7C_____13)
 

--- a/docs/functions/Set-TppAttribute.md
+++ b/docs/functions/Set-TppAttribute.md
@@ -11,9 +11,9 @@ Set-TppAttribute [-Path] <String[]> [-AttributeName] <String> [-Value] <String[]
 ```
 
 ## DESCRIPTION
-Write a value to the object's configuration. 
-This function will append by default. 
-Attributes can have multiple values which may not be the intended use. 
+Write a value to the object's configuration.
+This function will append by default.
+Attributes can have multiple values which may not be the intended use.
 To ensure you only have one value for an attribute, use the Overwrite switch.
 
 ## EXAMPLES
@@ -23,7 +23,7 @@ To ensure you only have one value for an attribute, use the Overwrite switch.
 Set-TppAttribute -Path '\VED\Policy\My Folder\app.company.com -AttributeName 'My custom field Label' -Value 'new custom value'
 ```
 
-Set value on custom field. 
+Set value on custom field.
 This will add to any existing value.
 
 ### EXAMPLE 2
@@ -51,7 +51,7 @@ Accept wildcard characters: False
 ```
 
 ### -AttributeName
-Name of the attribute to modify. 
+Name of the attribute to modify.
 If modifying a custom field, use the Label.
 
 ```yaml
@@ -97,7 +97,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -161,7 +161,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Set-TppAttribute/](http://venafitppps.readthedocs.io/en/latest/functions/Set-TppAttribute/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppAttribute.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppAttribute.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppAttribute.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-addvalue.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____4](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-addvalue.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____4)
 

--- a/docs/functions/Set-TppCodeSignProjectStatus.md
+++ b/docs/functions/Set-TppCodeSignProjectStatus.md
@@ -40,7 +40,7 @@ Accept wildcard characters: False
 ```
 
 ### -Status
-New project status, must have the appropriate perms. 
+New project status, must have the appropriate perms.
 Status can be Disabled, Enabled, Draft, or Pending.
 
 ```yaml
@@ -57,7 +57,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -118,7 +118,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Set-TppCodeSignProjectStatus/](http://venafitppps.readthedocs.io/en/latest/functions/Set-TppCodeSignProjectStatus/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppCodeSignProjectStatus.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-UpdateProjectStatus.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____14](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/CodeSignSDK/r-SDKc-POST-Codesign-UpdateProjectStatus.php?tocpath=CodeSign%20Protect%20Admin%20REST%C2%A0API%7CProjects%20and%20environments%7C_____14)
 

--- a/docs/functions/Set-TppPermission.md
+++ b/docs/functions/Set-TppPermission.md
@@ -43,13 +43,13 @@ $id = Find-TppIdentity -Name 'brownstein' | Select-Object -ExpandProperty Identi
 
 Find-TppObject -Path '\VED' -Recursive | Get-TppPermission -IdentityId $id | Set-TppPermission -Permission $TppPermObject -Force
 
-Reset permissions for a specific user/group for all objects. 
+Reset permissions for a specific user/group for all objects.
 Note the use of -Force to overwrite existing permissions.
 
 ## PARAMETERS
 
 ### -Path
-Path to an object. 
+Path to an object.
 Can pipe output from many other functions.
 
 ```yaml
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -IdentityId
-The id that represents the user or group. 
+The id that represents the user or group.
 You can use Find-TppIdentity or Get-TppPermission to get the id.
 
 ```yaml
@@ -96,7 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -Permission
-TppPermission object. 
+TppPermission object.
 You can create a new object or get existing object from Get-TppPermission.
 
 ```yaml
@@ -127,7 +127,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -189,7 +189,7 @@ Confirmation impact is set to Medium, set ConfirmPreference accordingly.
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Set-TppPermission/](http://venafitppps.readthedocs.io/en/latest/functions/Set-TppPermission/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppPermission.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppPermission.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppPermission.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppPermission.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Permissions-object-guid-principal.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____8](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Permissions-object-guid-principal.php?tocpath=Web%20SDK%7CPermissions%20programming%20interface%7C_____8)
 

--- a/docs/functions/Set-TppWorkflowTicketStatus.md
+++ b/docs/functions/Set-TppWorkflowTicketStatus.md
@@ -111,7 +111,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Set-TppWorkflowTicketStatus/](http://venafitppps.readthedocs.io/en/latest/functions/Set-TppWorkflowTicketStatus/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Set-TppWorkflowTicketStatus.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Workflow-ticket-updatestatus.php?tocpath=Web%20SDK%7CWorkflow%20Ticket%20programming%20interface%7C_____10](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Workflow-ticket-updatestatus.php?tocpath=Web%20SDK%7CWorkflow%20Ticket%20programming%20interface%7C_____10)
 

--- a/docs/functions/Test-TppIdentity.md
+++ b/docs/functions/Test-TppIdentity.md
@@ -46,7 +46,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExistOnly
-Only return boolean instead of ID and Exists list. 
+Only return boolean instead of ID and Exists list.
 Helpful when validating just 1 identity.
 
 ```yaml
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -92,7 +92,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Test-TppIdentity/](http://venafitppps.readthedocs.io/en/latest/functions/Test-TppIdentity/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Test-TppIdentity.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Test-TppIdentity.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Test-TppIdentity.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Test-TppIdentity.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Identity-Validate.php?tocpath=Web%20SDK%7CIdentity%20programming%20interface%7C_____15)
 

--- a/docs/functions/Test-TppObject.md
+++ b/docs/functions/Test-TppObject.md
@@ -42,8 +42,8 @@ Retrieve existence for only one object
 ## PARAMETERS
 
 ### -Path
-DN path to object. 
-Provide either this or Guid. 
+DN path to object.
+Provide either this or Guid.
 This is the default if both are provided.
 
 ```yaml
@@ -59,7 +59,7 @@ Accept wildcard characters: False
 ```
 
 ### -Guid
-Guid which represents a unqiue object. 
+Guid which represents a unqiue object.
 Provide either this or Path.
 
 ```yaml
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExistOnly
-Only return boolean instead of Object and Exists list. 
+Only return boolean instead of Object and Exists list.
 Helpful when validating just 1 object.
 
 ```yaml
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -121,7 +121,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/](http://venafitppps.readthedocs.io/en/latest/functions/Test-TppObject/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Test-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Test-TppObject.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Test-TppObject.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Test-TppObject.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-isvalid.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____25](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-isvalid.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____25)
 

--- a/docs/functions/Write-TppLog.md
+++ b/docs/functions/Write-TppLog.md
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 ```
 
 ### -EventId
-Event ID from within the EventGroup provided. 
+Event ID from within the EventGroup provided.
 Only provide the 4 character event id, do not precede with group ID.
 
 ```yaml
@@ -159,7 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -Text1
-String data to write to log. 
+String data to write to log.
 See link for event ID messages for more info.
 
 ```yaml
@@ -175,7 +175,7 @@ Accept wildcard characters: False
 ```
 
 ### -Text2
-String data to write to log. 
+String data to write to log.
 See link for event ID messages for more info.
 
 ```yaml
@@ -191,7 +191,7 @@ Accept wildcard characters: False
 ```
 
 ### -Value1
-Integer data to write to log. 
+Integer data to write to log.
 See link for event ID messages for more info.
 
 ```yaml
@@ -207,7 +207,7 @@ Accept wildcard characters: False
 ```
 
 ### -Value2
-Integer data to write to log. 
+Integer data to write to log.
 See link for event ID messages for more info.
 
 ```yaml
@@ -223,7 +223,7 @@ Accept wildcard characters: False
 ```
 
 ### -TppSession
-Session object created from New-TppSession method. 
+Session object created from New-TppSession method.
 The value defaults to the script session object $TppSession.
 
 ```yaml
@@ -284,7 +284,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [http://venafitppps.readthedocs.io/en/latest/functions/Write-TppLog/](http://venafitppps.readthedocs.io/en/latest/functions/Write-TppLog/)
 
-[https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Write-TppLog.ps1](https://github.com/gdbarron/VenafiTppPS/blob/master/VenafiTppPS/Code/Public/Write-TppLog.ps1)
+[https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Write-TppLog.ps1](https://github.com/gdbarron/VenafiTppPS/blob/main/VenafiTppPS/Code/Public/Write-TppLog.ps1)
 
 [https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Log.php?tocpath=Web%20SDK%7CLog%20programming%20interface%7C_____3](https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Log.php?tocpath=Web%20SDK%7CLog%20programming%20interface%7C_____3)
 


### PR DESCRIPTION
- Rename 'Provision' to 'Push', aliases added for existing code
- Add Invoke-TppCertificatePush
- Fix #130, Get-TppDevice only accepting IP address for host, not hostname.  Thanks @Curtmcgirt!
- Fix #131, add examples to `New-TppCapiApplication`.  Thanks @Curtmcgirt!
- Fix #132, 500 error setting BindingIpAddress running `New-TppCapiApplication`.    Thanks @Curtmcgirt!
- Fix #134, server url is blank when running `Get-TppObject` with secondary token.  This was an issue for Get-TppPermission as well.  Thanks @stevekeever!
- Add missing parameters comment-based help for `New-TppCapiApplication`
- Fix certificate push not working in `New-TppCapiApplication`