### PR TITLE
Add -KeystorePassword to Get-TppCertificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.4
+- Add `-KeystorePassword` option to `Get-TppCertificate`.  [#147](https://github.com/gdbarron/VenafiTppPS/issues/147).  Thanks @Curtmcgirt!
+
 ## 2.2.3
 - Fix [#145](https://github.com/gdbarron/VenafiTppPS/issues/145), `Revoke-TppToken` doesn't show target.  Thanks @wilddev65!
 

--- a/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiTppPS/Code/Private/Write-VerboseWithSecret.ps1
@@ -37,7 +37,7 @@ function Write-VerboseWithSecret {
         [psobject] $InputObject,
 
         [Parameter()]
-        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization')
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'PrivateKeyPassword')
     )
 
     begin {


### PR DESCRIPTION
keystore password option was never implemented for jks so it was added.  removed the need for `-IncludePrivateKey` switch and just the password, renamed from SecurePassword to PrivateKeyPassword, is enough to trigger private key inclusion.  help updates.  initiated by #147.